### PR TITLE
docs: add comprehensive README with pipeline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,218 @@
+# Signage
+
+Personal digital signage system for Pixoo64 and other displays.
+
+## Overview
+
+Signage is a serverless system that pushes real-time content to LED matrix displays. It uses AWS infrastructure to manage connections and broadcast frames to multiple terminals simultaneously.
+
+```
+┌─────────────┐     ┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│   Lambda    │────▶│  WebSocket  │────▶│    Relay     │────▶│   Pixoo64   │
+│  (content)  │     │     API     │     │    (CLI)     │     │  (display)  │
+└─────────────┘     └──────┬──────┘     └──────────────┘     └─────────────┘
+                          │
+                          │             ┌──────────────┐
+                          └────────────▶│ Web Emulator │
+                                        │  (browser)   │
+                                        └──────────────┘
+```
+
+## Quick Start
+
+### View the Web Emulator
+
+Open the web emulator in your browser:
+```
+https://d3138ekbi7z9yw.cloudfront.net
+```
+
+### Send a Test Frame
+
+Trigger a test pattern (broadcasts to all connected terminals):
+
+```bash
+# Rainbow gradient
+curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=rainbow"
+
+# Color bars
+curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=bars"
+
+# Custom text
+curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=text&text=Hello&color=pink"
+```
+
+### Run the Relay (for Pixoo64)
+
+Connect a local Pixoo64 device to the cloud:
+
+```bash
+cd packages/relay
+pnpm build
+node dist/cli.js --pixoo <PIXOO_IP> --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com
+```
+
+Find your Pixoo's IP in the Divoom app under Device Settings.
+
+## Architecture
+
+### Packages
+
+| Package | Description |
+|---------|-------------|
+| `packages/core` | Shared types and Pixoo protocol (RGB encoding, frame utilities) |
+| `packages/functions` | Lambda handlers for WebSocket API and test endpoints |
+| `packages/relay` | CLI that bridges AWS WebSocket to local Pixoo HTTP API |
+| `packages/web` | React web emulator with canvas-based 64×64 display |
+
+### Infrastructure (SST v3)
+
+- **WebSocket API** - Maintains persistent connections to terminals
+- **DynamoDB** - Stores connection state
+- **CloudFront** - Serves the web emulator
+- **Lambda** - Handles WebSocket events and content generation
+
+### Data Flow
+
+1. **Content Generation**: Lambda creates a 64×64 RGB frame
+2. **Broadcast**: Frame is sent via WebSocket to all connected terminals
+3. **Display**:
+   - Web emulator renders to canvas
+   - Relay forwards to Pixoo via local HTTP API
+
+## Test Endpoint
+
+The test endpoint generates frames and broadcasts to all connected terminals.
+
+### Parameters
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `pattern` | `rainbow`, `bars`, `text` | `rainbow` | Frame pattern to generate |
+| `text` | any string | `Hello` | Text to display (pattern=text only) |
+| `color` | `white`, `red`, `green`, `blue`, `yellow`, `cyan`, `magenta`, `orange`, `pink` | `white` | Text color |
+| `width` | integer | `64` | Frame width |
+| `height` | integer | `64` | Frame height |
+
+### Examples
+
+```bash
+# Rainbow gradient
+curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com"
+
+# Pink text saying "Hi"
+curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=text&text=Hi&color=pink"
+
+# Multi-line text (use \n)
+curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=text&text=Line1\\nLine2"
+
+# Color test bars
+curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=bars"
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "pattern": "text",
+  "width": 64,
+  "height": 64,
+  "connections": {
+    "total": 2,
+    "success": 2,
+    "failed": 0
+  }
+}
+```
+
+## Relay CLI
+
+The relay bridges the AWS WebSocket API to a local Pixoo device.
+
+### Installation
+
+```bash
+cd packages/relay
+pnpm install
+pnpm build
+```
+
+### Usage
+
+```bash
+node dist/cli.js --pixoo <IP> --ws <WEBSOCKET_URL> [--terminal <ID>]
+```
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--pixoo <ip>` | Yes | Pixoo device IP address |
+| `--ws <url>` | Yes | WebSocket API URL |
+| `--terminal <id>` | No | Terminal ID to register as |
+
+### Features
+
+- **Auto-reconnect**: Exponential backoff (1s → 30s) on disconnect
+- **Keepalive**: Sends ping every 5 minutes to prevent idle timeout
+- **Channel switch**: Automatically switches Pixoo to custom channel on startup
+
+### Example
+
+```bash
+# Connect to production
+node dist/cli.js \
+  --pixoo 192.168.1.100 \
+  --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com
+
+# With terminal ID
+node dist/cli.js \
+  --pixoo 192.168.1.100 \
+  --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com \
+  --terminal living-room
+```
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+
+- pnpm 9+
+- AWS account with credentials configured
+
+### Setup
+
+```bash
+# Install dependencies
+pnpm install
+
+# Start SST dev mode (deploys to AWS)
+pnpm dev
+
+# Run tests
+pnpm test
+
+# Build all packages
+pnpm build
+```
+
+### Deploy
+
+```bash
+# Deploy to dev stage
+pnpm deploy
+
+# Deploy to production
+pnpm deploy:prod
+```
+
+## Deployed URLs
+
+| Resource | URL |
+|----------|-----|
+| Web Emulator | https://d3138ekbi7z9yw.cloudfront.net |
+| Test API | https://hpaqthkicl.execute-api.us-east-1.amazonaws.com |
+| WebSocket | wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com |
+
+## License
+
+Private project - not for distribution.

--- a/changes/2026-01-15-0700-pipeline-documentation.md
+++ b/changes/2026-01-15-0700-pipeline-documentation.md
@@ -1,0 +1,33 @@
+# Pipeline Documentation
+
+*Date: 2026-01-15 0700*
+
+## Why
+
+The signage system was fully functional but undocumented. New users (or future self) would have no way to understand how to use the system without reading through source code.
+
+Issue #30 required documenting the working pipeline with examples.
+
+## How
+
+Created comprehensive README.md covering:
+
+1. **Architecture overview** - ASCII diagram showing data flow
+2. **Quick start** - Three commands to see the system work
+3. **Test endpoint** - Full parameter documentation with curl examples
+4. **Relay CLI** - Installation, usage, and feature documentation
+5. **Development setup** - Prerequisites, commands, deployment
+6. **Deployed URLs** - All production endpoints in one table
+
+## Key Design Decisions
+
+- **Quick start first**: Users can see something working in 30 seconds before diving into details
+- **Curl examples**: No dependencies needed to test - just copy/paste
+- **ASCII diagram**: Works in terminal, GitHub, and any text editor
+- **Single README**: Everything in one place rather than scattered docs
+
+## What's Next
+
+- Add demo GIF to README (requires screen recording)
+- Consider adding widget development guide when widgets are built
+- Keep deployed URLs updated if infrastructure changes


### PR DESCRIPTION
## Summary
- Architecture overview with ASCII diagram
- Quick start guide (web emulator, test API, relay)
- Full test endpoint documentation with curl examples
- Relay CLI usage and features
- Development and deployment instructions
- Deployed URLs table

Closes #30

## Test plan
- [x] README renders correctly on GitHub
- [ ] Quick start commands work as documented
- [ ] All URLs are correct and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)