### PR TITLE
feat(relay): add Pixoo device discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Connect a local Pixoo64 device to the cloud:
 ```bash
 cd packages/relay
 pnpm build
-node dist/cli.js --pixoo <PIXOO_IP> --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com
+node dist/cli.js --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com
 ```
 
-Find your Pixoo's IP in the Divoom app under Device Settings.
+On first run, it will ask to scan for your Pixoo and save the IP for next time.
 
 ## Architecture
 
@@ -141,32 +141,57 @@ pnpm build
 ### Usage
 
 ```bash
-node dist/cli.js --pixoo <IP> --ws <WEBSOCKET_URL> [--terminal <ID>]
+# First run - prompts to scan for Pixoo
+node dist/cli.js --ws <WEBSOCKET_URL>
+
+# Specify IP manually
+node dist/cli.js --pixoo <IP> --ws <WEBSOCKET_URL>
+
+# Scan network
+node dist/cli.js scan
+
+# Forget saved IP
+node dist/cli.js forget
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--pixoo <ip>` | Yes | Pixoo device IP address |
+| `--pixoo <ip>` | No | Pixoo device IP (saved for next time) |
 | `--ws <url>` | Yes | WebSocket API URL |
 | `--terminal <id>` | No | Terminal ID to register as |
 
+### First Run
+
+On first run without `--pixoo`, the relay will:
+
+1. Ask if you want to scan the network
+2. Scan your subnet for Pixoo devices
+3. Let you select a device (if multiple found)
+4. Save the IP to `~/.signage/config.json`
+
+Future runs use the saved IP automatically.
+
 ### Features
 
+- **Auto-discovery**: Scans local network for Pixoo devices
+- **Persistent config**: Saves IP so you only scan once
 - **Auto-reconnect**: Exponential backoff (1s → 30s) on disconnect
 - **Keepalive**: Sends ping every 5 minutes to prevent idle timeout
 - **Channel switch**: Automatically switches Pixoo to custom channel on startup
 
-### Example
+### Examples
 
 ```bash
-# Connect to production
+# Normal usage (uses saved IP or prompts to scan)
+node dist/cli.js --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com
+
+# Specify IP (saves for next time)
 node dist/cli.js \
   --pixoo 192.168.1.100 \
   --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com
 
 # With terminal ID
 node dist/cli.js \
-  --pixoo 192.168.1.100 \
   --ws wss://by1t5j0e7h.execute-api.us-east-1.amazonaws.com \
   --terminal living-room
 ```

--- a/changes/2026-01-15-0715-device-discovery.md
+++ b/changes/2026-01-15-0715-device-discovery.md
@@ -1,0 +1,43 @@
+# Pixoo Device Discovery
+
+*Date: 2026-01-15 0715*
+
+## Why
+
+Users needed to know their Pixoo's IP address to use the relay. This required opening the Divoom app, navigating to device settings, and manually copying the IP.
+
+## How
+
+Added simple local network scan with IP persistence:
+
+1. **First run**: Prompts "Scan network for Pixoo devices?"
+2. **Scans subnet**: Probes port 80 for Pixoo REST API
+3. **Saves IP**: Stores in `~/.signage/config.json`
+4. **Next run**: Uses saved IP automatically
+
+### Commands
+
+```bash
+# Normal usage (prompts if no IP saved)
+signage-relay --ws wss://...
+
+# Specify IP manually (saves for next time)
+signage-relay --pixoo 192.168.1.100 --ws wss://...
+
+# Scan network
+signage-relay scan
+
+# Forget saved IP
+signage-relay forget
+```
+
+## Key Design Decisions
+
+- **No cloud dependency**: Only local subnet scan, works offline
+- **Interactive flow**: Asks before scanning, doesn't assume
+- **Persistent config**: Scans once, remembers forever
+- **Simple storage**: Plain JSON in `~/.signage/config.json`
+
+## What's Next
+
+- Could verify saved IP is still valid before connecting

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -1,40 +1,176 @@
 #!/usr/bin/env node
 /**
  * Signage Relay CLI
- *
- * Connects to AWS WebSocket API and relays frames to local Pixoo device
- *
- * Usage:
- *   pnpm relay --pixoo 192.168.1.100 --ws wss://xxx.execute-api.us-east-1.amazonaws.com/prod
  */
 
 import { program } from "commander";
+import { createInterface } from "readline";
 import { startRelay } from "./relay";
+import { scanForDevices, getSavedPixooIp, savePixooIp } from "./discovery";
+
+/**
+ * Prompt user for yes/no
+ */
+function confirm(question: string): Promise<boolean> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(`${question} (y/n) `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase().startsWith("y"));
+    });
+  });
+}
+
+/**
+ * Prompt user to select from list
+ */
+function selectFromList(items: string[], prompt: string): Promise<number> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  console.log(prompt);
+  items.forEach((item, i) => console.log(`  ${i + 1}. ${item}`));
+
+  return new Promise((resolve) => {
+    rl.question("Enter number: ", (answer) => {
+      rl.close();
+      const num = parseInt(answer, 10);
+      resolve(num >= 1 && num <= items.length ? num - 1 : 0);
+    });
+  });
+}
+
+/**
+ * Get Pixoo IP - from arg, saved config, or scan
+ */
+async function getPixooIp(providedIp?: string): Promise<string | null> {
+  // 1. Use provided IP
+  if (providedIp) {
+    savePixooIp(providedIp);
+    return providedIp;
+  }
+
+  // 2. Use saved IP
+  const savedIp = getSavedPixooIp();
+  if (savedIp) {
+    console.log(`Using saved Pixoo IP: ${savedIp}`);
+    console.log(`(Run with --pixoo <ip> to change)\n`);
+    return savedIp;
+  }
+
+  // 3. Ask to scan
+  console.log("No Pixoo IP configured.\n");
+  const shouldScan = await confirm("Scan network for Pixoo devices?");
+
+  if (!shouldScan) {
+    console.log("\nRun with --pixoo <ip> to specify device.");
+    return null;
+  }
+
+  // 4. Scan
+  console.log("\nScanning network...");
+  const devices = await scanForDevices((current, total) => {
+    process.stdout.write(`\r  Progress: ${current}/${total}`);
+  });
+  console.log("\n");
+
+  if (devices.length === 0) {
+    console.log("No Pixoo devices found.");
+    console.log("Make sure your Pixoo is on and connected to WiFi.");
+    return null;
+  }
+
+  // 5. Select device
+  let selectedIp: string;
+  if (devices.length === 1) {
+    selectedIp = devices[0].ip;
+    console.log(`Found: ${devices[0].ip}`);
+  } else {
+    const idx = await selectFromList(
+      devices.map((d) => d.ip),
+      `Found ${devices.length} devices:`
+    );
+    selectedIp = devices[idx].ip;
+  }
+
+  // 6. Save for next time
+  savePixooIp(selectedIp);
+  console.log(`Saved ${selectedIp} to ~/.signage/config.json\n`);
+
+  return selectedIp;
+}
 
 program
   .name("signage-relay")
   .description("Relay frames from AWS to local Pixoo device")
   .version("0.1.0")
-  .requiredOption("--pixoo <ip>", "Pixoo device IP address")
+  .option("--pixoo <ip>", "Pixoo device IP address")
   .requiredOption("--ws <url>", "WebSocket API URL")
   .option("--terminal <id>", "Terminal ID to register as")
   .action(async (options) => {
+    const pixooIp = await getPixooIp(options.pixoo);
+
+    if (!pixooIp) {
+      process.exit(1);
+    }
+
     console.log("Starting Signage Relay...");
-    console.log(`  Pixoo: ${options.pixoo}`);
+    console.log(`  Pixoo: ${pixooIp}`);
     console.log(`  WebSocket: ${options.ws}`);
     if (options.terminal) {
       console.log(`  Terminal ID: ${options.terminal}`);
     }
+    console.log();
 
     try {
       await startRelay({
-        pixooIp: options.pixoo,
+        pixooIp,
         wsUrl: options.ws,
         terminalId: options.terminal,
       });
     } catch (error) {
       console.error("Relay error:", error);
       process.exit(1);
+    }
+  });
+
+// Scan command for manual discovery
+program
+  .command("scan")
+  .description("Scan network for Pixoo devices")
+  .action(async () => {
+    console.log("Scanning network for Pixoo devices...\n");
+
+    const devices = await scanForDevices((current, total) => {
+      process.stdout.write(`\r  Progress: ${current}/${total}`);
+    });
+    console.log("\n");
+
+    if (devices.length === 0) {
+      console.log("No Pixoo devices found.");
+    } else {
+      console.log(`Found ${devices.length} device(s):`);
+      devices.forEach((d) => console.log(`  - ${d.ip}`));
+    }
+  });
+
+// Clear saved config
+program
+  .command("forget")
+  .description("Forget saved Pixoo IP")
+  .action(() => {
+    const savedIp = getSavedPixooIp();
+    if (savedIp) {
+      savePixooIp("");
+      console.log(`Forgot saved IP: ${savedIp}`);
+    } else {
+      console.log("No saved IP to forget.");
     }
   });
 

--- a/packages/relay/src/discovery.test.ts
+++ b/packages/relay/src/discovery.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  loadConfig,
+  saveConfig,
+  getSavedPixooIp,
+  savePixooIp,
+} from "./discovery";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+
+// Mock fs
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+describe("config persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("loadConfig", () => {
+    it("returns empty object when file doesn't exist", () => {
+      vi.mocked(readFileSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      const config = loadConfig();
+      expect(config).toEqual({});
+    });
+
+    it("parses config from file", () => {
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ pixooIp: "192.168.1.100" })
+      );
+
+      const config = loadConfig();
+      expect(config.pixooIp).toBe("192.168.1.100");
+    });
+
+    it("returns empty object on parse error", () => {
+      vi.mocked(readFileSync).mockReturnValue("invalid json");
+
+      const config = loadConfig();
+      expect(config).toEqual({});
+    });
+  });
+
+  describe("saveConfig", () => {
+    it("creates directory and writes file", () => {
+      saveConfig({ pixooIp: "192.168.1.100" });
+
+      expect(mkdirSync).toHaveBeenCalled();
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("config.json"),
+        expect.stringContaining("192.168.1.100")
+      );
+    });
+  });
+
+  describe("getSavedPixooIp", () => {
+    it("returns undefined when no IP saved", () => {
+      vi.mocked(readFileSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      expect(getSavedPixooIp()).toBeUndefined();
+    });
+
+    it("returns saved IP", () => {
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ pixooIp: "192.168.1.100" })
+      );
+
+      expect(getSavedPixooIp()).toBe("192.168.1.100");
+    });
+  });
+
+  describe("savePixooIp", () => {
+    it("saves IP to config", () => {
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}));
+
+      savePixooIp("192.168.1.100");
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining("192.168.1.100")
+      );
+    });
+  });
+});

--- a/packages/relay/src/discovery.ts
+++ b/packages/relay/src/discovery.ts
@@ -1,0 +1,134 @@
+/**
+ * Pixoo device discovery via local subnet scan
+ */
+
+import { networkInterfaces } from "os";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export interface PixooDevice {
+  name: string;
+  ip: string;
+}
+
+const CONFIG_DIR = join(homedir(), ".signage");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+interface Config {
+  pixooIp?: string;
+}
+
+/**
+ * Load saved config
+ */
+export function loadConfig(): Config {
+  try {
+    const data = readFileSync(CONFIG_FILE, "utf-8");
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Save config
+ */
+export function saveConfig(config: Config): void {
+  try {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+    writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+  } catch (error) {
+    console.error("Failed to save config:", error);
+  }
+}
+
+/**
+ * Get saved Pixoo IP
+ */
+export function getSavedPixooIp(): string | undefined {
+  return loadConfig().pixooIp;
+}
+
+/**
+ * Save Pixoo IP for future use
+ */
+export function savePixooIp(ip: string): void {
+  const config = loadConfig();
+  config.pixooIp = ip;
+  saveConfig(config);
+}
+
+/**
+ * Get local subnet
+ */
+function getLocalSubnet(): string | null {
+  const interfaces = networkInterfaces();
+  for (const name of Object.keys(interfaces)) {
+    for (const iface of interfaces[name] || []) {
+      if (iface.family === "IPv4" && !iface.internal) {
+        return iface.address.split(".").slice(0, 3).join(".");
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if an IP hosts a Pixoo device
+ */
+async function probePixoo(ip: string): Promise<PixooDevice | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 500);
+
+  try {
+    const response = await fetch(`http://${ip}:80/post`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ Command: "Channel/GetIndex" }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as { error_code?: number };
+    if (data?.error_code === 0) {
+      return { name: "Pixoo", ip };
+    }
+  } catch {
+    // Not a Pixoo
+  } finally {
+    clearTimeout(timeoutId);
+  }
+  return null;
+}
+
+/**
+ * Scan local subnet for Pixoo devices
+ */
+export async function scanForDevices(
+  onProgress?: (current: number, total: number) => void
+): Promise<PixooDevice[]> {
+  const subnet = getLocalSubnet();
+  if (!subnet) {
+    throw new Error("Could not determine local network");
+  }
+
+  const devices: PixooDevice[] = [];
+  const batchSize = 50;
+
+  for (let start = 1; start <= 254; start += batchSize) {
+    const promises: Promise<PixooDevice | null>[] = [];
+
+    for (let i = start; i < start + batchSize && i <= 254; i++) {
+      promises.push(probePixoo(`${subnet}.${i}`));
+    }
+
+    const results = await Promise.all(promises);
+    devices.push(...results.filter((d): d is PixooDevice => d !== null));
+
+    onProgress?.(Math.min(start + batchSize - 1, 254), 254);
+  }
+
+  return devices;
+}


### PR DESCRIPTION
## Summary
- Adds local subnet scan for Pixoo device discovery
- Persists discovered IP to `~/.signage/config.json`
- Interactive prompts when no IP configured
- Adds `scan` and `forget` commands

Closes #19

## Usage

```bash
# Normal usage (uses saved IP or prompts to scan)
signage-relay --ws wss://...

# Specify IP manually (saves for next time)
signage-relay --pixoo 192.168.1.100 --ws wss://...

# Scan network for devices
signage-relay scan

# Forget saved IP
signage-relay forget
```

## Key Design Decisions
- **No cloud dependency**: Only local subnet scan, works offline
- **Interactive flow**: Asks before scanning, doesn't assume
- **Persistent config**: Scans once, remembers forever
- **Simple storage**: Plain JSON in `~/.signage/config.json`

## Test plan
- [x] Unit tests for config persistence (7 tests)
- [x] All tests pass (18 total)
- [ ] Manual test: run without saved IP (should prompt)
- [ ] Manual test: run `scan` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)