### PR TITLE
fix: force HTTP/1.1 for WebSocket connections to AWS API Gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,15 @@ Key files:
 ### Relay (`packages/relay`)
 Local CLI that bridges AWS to Pixoo.
 
+**Current Pixoo IP**: `192.168.1.224`
+**Production WebSocket**: `wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default`
+
 ```bash
 cd packages/relay
-pnpm dev --pixoo 192.168.1.100 --ws wss://xxx.execute-api.us-east-1.amazonaws.com/prod
+
+# IMPORTANT: Use npx tsx directly, NOT pnpm dev
+# pnpm expands $default as an empty shell variable
+npx tsx src/cli.ts --pixoo 192.168.1.224 --ws 'wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default'
 ```
 
 ### Web (`packages/web`)

--- a/packages/relay/src/relay.ts
+++ b/packages/relay/src/relay.ts
@@ -4,10 +4,16 @@
  */
 
 import WebSocket from "ws";
+import https from "https";
 import { sendFrameToPixoo, initializePixoo } from "./pixoo-client";
 import type { WsMessage, FramePayload } from "@signage/core";
 import { decodeBase64ToPixels } from "@signage/core";
 import { createBackoffController } from "./backoff";
+
+// Force HTTP/1.1 to prevent ALPN from negotiating HTTP/2 (which doesn't support WebSocket)
+const agent = new https.Agent({
+  ALPNProtocols: ["http/1.1"],
+});
 
 export interface RelayOptions {
   pixooIp: string;
@@ -33,7 +39,7 @@ export async function startRelay(options: RelayOptions): Promise<void> {
 
   const connect = () => {
     console.log("Connecting to WebSocket...");
-    const ws = new WebSocket(wsUrl);
+    const ws = new WebSocket(wsUrl, { agent });
 
     let pingInterval: NodeJS.Timeout | null = null;
 


### PR DESCRIPTION
## Summary
- Force HTTP/1.1 for relay WebSocket connections (AWS API Gateway doesn't support HTTP/2 WebSocket upgrades)
- Document Pixoo IP and production WebSocket URL in CLAUDE.md
- Note pnpm `$default` shell expansion issue

## Test plan
- [x] Tested relay connection to production WebSocket
- [x] Verified Pixoo receives frames via direct API call
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)