### PR TITLE
fix: add .js extensions to ESM imports

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
 // @signage/core - Shared types and Pixoo protocol implementation
 
-export * from "./types";
-export * from "./pixoo";
+export * from "./types.js";
+export * from "./pixoo.js";

--- a/packages/core/src/pixoo.ts
+++ b/packages/core/src/pixoo.ts
@@ -11,7 +11,7 @@
  * - Total: 64 * 64 * 3 = 12,288 bytes raw, ~16KB base64
  */
 
-import type { Frame, RGB } from "./types";
+import type { Frame, RGB } from "./types.js";
 
 /** Default Pixoo64 display size */
 export const PIXOO64_SIZE = 64;

--- a/packages/functions/src/test-bitmap.ts
+++ b/packages/functions/src/test-bitmap.ts
@@ -13,7 +13,7 @@ import { Resource } from "sst";
 import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
 import { createSolidFrame, setPixel, encodeFrameToBase64 } from "@signage/core";
 import type { RGB, Frame } from "@signage/core";
-import { getCharBitmap, CHAR_WIDTH, CHAR_HEIGHT, measureText } from "./font";
+import { getCharBitmap, CHAR_WIDTH, CHAR_HEIGHT, measureText } from "./font.js";
 
 const ddbClient = new DynamoDBClient({});
 const ddb = DynamoDBDocumentClient.from(ddbClient);

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -5,8 +5,8 @@
 
 import { program } from "commander";
 import { createInterface } from "readline";
-import { startRelay } from "./relay";
-import { scanForDevices, getSavedPixooIp, savePixooIp } from "./discovery";
+import { startRelay } from "./relay.js";
+import { scanForDevices, getSavedPixooIp, savePixooIp } from "./discovery.js";
 
 /**
  * Prompt user for yes/no

--- a/packages/relay/src/relay.ts
+++ b/packages/relay/src/relay.ts
@@ -5,10 +5,10 @@
 
 import WebSocket from "ws";
 import https from "https";
-import { sendFrameToPixoo, initializePixoo } from "./pixoo-client";
+import { sendFrameToPixoo, initializePixoo } from "./pixoo-client.js";
 import type { WsMessage, FramePayload } from "@signage/core";
 import { decodeBase64ToPixels } from "@signage/core";
-import { createBackoffController } from "./backoff";
+import { createBackoffController } from "./backoff.js";
 
 // Force HTTP/1.1 to prevent ALPN from negotiating HTTP/2 (which doesn't support WebSocket)
 const agent = new https.Agent({


### PR DESCRIPTION
## Summary
- Adds `.js` extensions to all local imports across packages
- Fixes "Cannot find module" errors when running compiled JavaScript
- Required for Node.js ES modules (package.json has `"type": "module"`)

## Files changed
- `packages/core/src/index.ts`
- `packages/core/src/pixoo.ts`
- `packages/relay/src/cli.ts`
- `packages/relay/src/relay.ts`
- `packages/functions/src/test-bitmap.ts`

## Test plan
- [x] All tests pass (18 tests)
- [x] Build succeeds
- [x] `node dist/cli.js --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)