### PR TITLE
fix: add inference-profile IAM permission for Nova models

### DIFF
--- a/infra/test-api.ts
+++ b/infra/test-api.ts
@@ -33,7 +33,10 @@ testApi.route("GET /news-digest", {
   permissions: [
     {
       actions: ["bedrock:InvokeModel"],
-      resources: ["arn:aws:bedrock:us-east-1::foundation-model/*"],
+      resources: [
+        "arn:aws:bedrock:us-east-1::foundation-model/*",
+        "arn:aws:bedrock:us-east-1:*:inference-profile/*",
+      ],
     },
   ],
   timeout: "30 seconds", // Allow time for Bedrock + cycling through headlines


### PR DESCRIPTION
## Summary
- Nova models use `inference-profile` ARNs, not `foundation-model` ARNs
- Added IAM permission for `arn:aws:bedrock:us-east-1:*:inference-profile/*`

## Test plan
- [ ] Deploy to dev
- [ ] Test: `curl "https://<api-url>/news-digest?topic=AI"`
- [ ] Verify headlines are returned (no IAM error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)