### PR TITLE
fix: allow bedrock access in all regions for cross-region inference

### DIFF
--- a/infra/test-api.ts
+++ b/infra/test-api.ts
@@ -34,8 +34,8 @@ testApi.route("GET /news-digest", {
     {
       actions: ["bedrock:InvokeModel"],
       resources: [
-        "arn:aws:bedrock:us-east-1::foundation-model/*",
-        "arn:aws:bedrock:us-east-1:*:inference-profile/*",
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*",
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- Cross-region inference profiles (`us.amazon.nova-lite-v1:0`) route to foundation models in various regions (e.g., us-west-2)
- Updated IAM to use region wildcard `arn:aws:bedrock:*::foundation-model/*`

## Test plan
- [ ] Deploy to dev
- [ ] Test: `curl "https://<api-url>/news-digest?topic=AI"`
- [ ] Verify headlines are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)