### PR TITLE
feat: add custom domains for stable URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,14 +142,20 @@ Key files:
 Local CLI that bridges AWS to Pixoo.
 
 **Current Pixoo IP**: `192.168.1.224`
-**Production WebSocket**: `wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default`
+
+| Environment | WebSocket URL |
+|-------------|---------------|
+| Production | `wss://ws.signage.wulfffamily.com` |
+| Development | `wss://ws.dev.signage.wulfffamily.com` |
 
 ```bash
 cd packages/relay
 
-# IMPORTANT: Use npx tsx directly, NOT pnpm dev
-# pnpm expands $default as an empty shell variable
-npx tsx src/cli.ts --pixoo 192.168.1.224 --ws 'wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default'
+# Production
+npx tsx src/cli.ts --ws wss://ws.signage.wulfffamily.com
+
+# Development
+npx tsx src/cli.ts --ws wss://ws.dev.signage.wulfffamily.com
 ```
 
 ### Web (`packages/web`)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Signage is a serverless system that pushes real-time content to LED matrix displ
 
 Open the web emulator in your browser:
 ```
-https://d3138ekbi7z9yw.cloudfront.net
+https://signage.wulfffamily.com
 ```
 
 ### Send a Test Frame
@@ -33,13 +33,13 @@ Trigger a test pattern (broadcasts to all connected terminals):
 
 ```bash
 # Rainbow gradient
-curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=rainbow"
+curl "https://api.signage.wulfffamily.com/test-bitmap?pattern=rainbow"
 
 # Color bars
-curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=bars"
+curl "https://api.signage.wulfffamily.com/test-bitmap?pattern=bars"
 
 # Custom text
-curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=text&text=Hello&color=pink"
+curl "https://api.signage.wulfffamily.com/test-bitmap?pattern=text&text=Hello&color=pink"
 ```
 
 ### Run the Relay (for Pixoo64)
@@ -49,7 +49,7 @@ Connect a local Pixoo64 device to the cloud:
 ```bash
 cd packages/relay
 pnpm build
-node dist/cli.js --ws 'wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default'
+node dist/cli.js --ws wss://ws.signage.wulfffamily.com
 ```
 
 On first run, it will ask to scan for your Pixoo and save the IP for next time.
@@ -98,16 +98,16 @@ The test endpoint generates frames and broadcasts to all connected terminals.
 
 ```bash
 # Rainbow gradient
-curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com"
+curl "https://api.signage.wulfffamily.com/test-bitmap"
 
 # Pink text saying "Hi"
-curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=text&text=Hi&color=pink"
+curl "https://api.signage.wulfffamily.com/test-bitmap?pattern=text&text=Hi&color=pink"
 
 # Multi-line text (use \n)
-curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=text&text=Line1\\nLine2"
+curl "https://api.signage.wulfffamily.com/test-bitmap?pattern=text&text=Line1\\nLine2"
 
 # Color test bars
-curl "https://hpaqthkicl.execute-api.us-east-1.amazonaws.com?pattern=bars"
+curl "https://api.signage.wulfffamily.com/test-bitmap?pattern=bars"
 ```
 
 ### Response
@@ -183,16 +183,16 @@ Future runs use the saved IP automatically.
 
 ```bash
 # Normal usage (uses saved IP or prompts to scan)
-node dist/cli.js --ws 'wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default'
+node dist/cli.js --ws wss://ws.signage.wulfffamily.com
 
 # Specify IP (saves for next time)
 node dist/cli.js \
   --pixoo 192.168.1.100 \
-  --ws 'wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default'
+  --ws wss://ws.signage.wulfffamily.com
 
 # With terminal ID
 node dist/cli.js \
-  --ws 'wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default' \
+  --ws wss://ws.signage.wulfffamily.com \
   --terminal living-room
 ```
 
@@ -232,11 +232,19 @@ pnpm deploy:prod
 
 ## Deployed URLs
 
+### Production
 | Resource | URL |
 |----------|-----|
-| Web Emulator | https://d3138ekbi7z9yw.cloudfront.net |
-| Test API | https://hpaqthkicl.execute-api.us-east-1.amazonaws.com |
-| WebSocket | wss://mew9rfc709.execute-api.us-east-1.amazonaws.com/$default |
+| Web Emulator | https://signage.wulfffamily.com |
+| Test API | https://api.signage.wulfffamily.com |
+| WebSocket | wss://ws.signage.wulfffamily.com |
+
+### Development
+| Resource | URL |
+|----------|-----|
+| Web Emulator | https://dev.signage.wulfffamily.com |
+| Test API | https://api.dev.signage.wulfffamily.com |
+| WebSocket | wss://ws.dev.signage.wulfffamily.com |
 
 ## License
 

--- a/changes/2026-01-18-0630-custom-domains.md
+++ b/changes/2026-01-18-0630-custom-domains.md
@@ -1,0 +1,26 @@
+# Custom Domains for Stable URLs
+
+*Date: 2026-01-18 0630*
+
+## Why
+
+API Gateway URLs changed on every deploy, requiring manual updates to documentation and causing confusion about which URL was current.
+
+## How
+
+Added custom domain configuration to all SST components using Route 53:
+
+- **WebSocket API**: `ws.signage.wulfffamily.com` (prod) / `ws.dev.signage.wulfffamily.com` (dev)
+- **HTTP API**: `api.signage.wulfffamily.com` (prod) / `api.dev.signage.wulfffamily.com` (dev)
+- **Static Site**: `signage.wulfffamily.com` (prod) / `dev.signage.wulfffamily.com` (dev)
+
+## Key Design Decisions
+
+- **Separate dev/prod domains**: Prevents accidental testing against production
+- **Subdomain pattern**: `ws.` prefix for WebSocket, `api.` prefix for HTTP, apex for web
+- **Route 53 integration**: SST automatically manages ACM certificates and DNS records
+
+## What's Next
+
+- First deploy will take ~5 minutes for certificate validation
+- URLs are now stable and won't change between deploys

--- a/infra/api.ts
+++ b/infra/api.ts
@@ -1,7 +1,12 @@
 import { table } from "./storage";
 
 // WebSocket API for terminal connections
-export const api = new sst.aws.ApiGatewayWebSocket("SignageApi", {});
+export const api = new sst.aws.ApiGatewayWebSocket("SignageApi", {
+  domain:
+    $app.stage === "prod"
+      ? "ws.signage.wulfffamily.com"
+      : `ws.${$app.stage}.signage.wulfffamily.com`,
+});
 
 // Connection handlers
 api.route("$connect", {

--- a/infra/test-api.ts
+++ b/infra/test-api.ts
@@ -3,6 +3,10 @@ import { table } from "./storage";
 
 // HTTP API for test endpoints
 export const testApi = new sst.aws.ApiGatewayV2("SignageTestApi", {
+  domain:
+    $app.stage === "prod"
+      ? "api.signage.wulfffamily.com"
+      : `api.${$app.stage}.signage.wulfffamily.com`,
   cors: {
     allowOrigins: ["*"],
     allowMethods: ["GET", "POST"],

--- a/infra/web.ts
+++ b/infra/web.ts
@@ -7,6 +7,10 @@ export const web = new sst.aws.StaticSite("SignageWeb", {
     command: "pnpm build",
     output: "dist",
   },
+  domain:
+    $app.stage === "prod"
+      ? "signage.wulfffamily.com"
+      : `${$app.stage}.signage.wulfffamily.com`,
   environment: {
     VITE_WEBSOCKET_URL: api.url,
   },


### PR DESCRIPTION
## Summary
- Adds custom domains under `signage.example.com` using Route 53
- Separate domains for dev and prod stages
- URLs no longer change between deploys

## Domain Structure

### Production (`--stage prod`)
| Service | Custom Domain |
|---------|---------------|
| WebSocket API | `wss://ws.signage.example.com` |
| HTTP API | `https://api.signage.example.com` |
| Static Site | `https://signage.example.com` |

### Development (`--stage dev`)
| Service | Custom Domain |
|---------|---------------|
| WebSocket API | `wss://ws.dev.signage.example.com` |
| HTTP API | `https://api.dev.signage.example.com` |
| Static Site | `https://dev.signage.example.com` |

## Files Changed
- `infra/api.ts` - WebSocket domain
- `infra/test-api.ts` - HTTP API domain
- `infra/web.ts` - Static site domain
- `README.md` - Updated URLs
- `CLAUDE.md` - Updated relay docs

## Test plan
- [x] All tests pass (38 tests)
- [ ] Deploy to dev stage
- [ ] Verify WebSocket connects at new domain
- [ ] Verify HTTP API responds at new domain
- [ ] Verify web emulator loads at new domain

## Notes
- First deploy will take ~5 minutes for ACM certificate validation
- SST auto-manages certificates and DNS records

🤖 Generated with [Claude Code](https://claude.com/claude-code)