### PR TITLE
feat: add blood sugar widget for Dexcom G7 glucose monitoring

### DIFF
--- a/changes/2026-01-18-2312-blood-sugar-widget.md
+++ b/changes/2026-01-18-2312-blood-sugar-widget.md
@@ -1,0 +1,29 @@
+# Blood Sugar Widget
+
+*Date: 2026-01-18 2312*
+
+## Why
+
+Abigail uses a Dexcom G7 continuous glucose monitor for Type 1 diabetes management. Having her current blood sugar reading displayed on the signage system provides at-a-glance visibility for the whole family without needing to check a phone.
+
+## How
+
+Created a new widget that fetches glucose data from the Dexcom Share API:
+- Uses the `dexcom-share-api` npm package to authenticate and retrieve readings
+- Runs every 1 minute to catch new readings quickly (Dexcom updates every 5 minutes)
+- Returns structured data including glucose value, trend arrow, and range status
+- Terminals handle display rendering based on the data
+
+## Key Design Decisions
+
+- **Data-only widget**: The widget returns structured data (glucose, trend, range status) rather than rendered frames. This keeps the widget simple and lets terminals decide how to display it.
+- **Standard T1D thresholds**: Using widely-accepted ranges (Low < 70, Normal 70-180, High > 180 mg/dL) for range classification.
+- **Stale data detection**: Marks readings as stale if >10 minutes old, so terminals can indicate when data may be outdated.
+- **Delta calculation**: Includes the change from the previous reading for context on glucose trends.
+- **US region hardcoded**: Since this is a personal project for a US user, the region is hardcoded to "us".
+
+## What's Next
+
+- Terminal rendering: Web emulator and Pixoo64 relay need to be updated to display the blood sugar widget
+- Alert thresholds: Could add configurable alert levels for urgent lows/highs
+- Historical trends: Could show mini graph of recent readings

--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -1,0 +1,7 @@
+/**
+ * SST Secrets for sensitive configuration
+ */
+
+// Dexcom Share API credentials
+export const dexcomUsername = new sst.Secret("DexcomUsername");
+export const dexcomPassword = new sst.Secret("DexcomPassword");

--- a/infra/widgets.ts
+++ b/infra/widgets.ts
@@ -5,6 +5,7 @@
 
 import { table } from "./storage";
 import { api } from "./api";
+import { dexcomUsername, dexcomPassword } from "./secrets";
 
 // Clock widget - updates every minute
 export const clockCron = new sst.aws.Cron("ClockWidget", {
@@ -24,6 +25,17 @@ export const reconcileCron = new sst.aws.Cron("ConnectionReconcile", {
     handler: "packages/functions/src/widgets/reconcile.handler",
     link: [table],
     timeout: "60 seconds",
+    memory: "256 MB",
+  },
+});
+
+// Blood sugar widget - updates every minute
+export const bloodSugarCron = new sst.aws.Cron("BloodsugarWidget", {
+  schedule: "rate(1 minute)",
+  function: {
+    handler: "packages/functions/src/widgets/dispatcher.handler",
+    link: [table, api, dexcomUsername, dexcomPassword],
+    timeout: "30 seconds",
     memory: "256 MB",
   },
 });

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -9,11 +9,12 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@signage/core": "workspace:*",
-    "@aws-sdk/client-dynamodb": "^3.700.0",
-    "@aws-sdk/lib-dynamodb": "^3.700.0",
     "@aws-sdk/client-apigatewaymanagementapi": "^3.700.0",
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
+    "@aws-sdk/client-dynamodb": "^3.700.0",
+    "@aws-sdk/lib-dynamodb": "^3.700.0",
+    "@signage/core": "workspace:*",
+    "dexcom-share-api": "^1.0.8",
     "sst": "^3.5.0"
   },
   "devDependencies": {

--- a/packages/functions/src/types/dexcom-share-api.d.ts
+++ b/packages/functions/src/types/dexcom-share-api.d.ts
@@ -1,0 +1,43 @@
+/**
+ * Type declarations for dexcom-share-api
+ * @see https://github.com/aud/dexcom-share-api
+ */
+declare module "dexcom-share-api" {
+  export interface DexcomClientOptions {
+    username: string;
+    password: string;
+    /** "us" for United States, "eu" for all other countries including Canada */
+    server: "us" | "eu";
+  }
+
+  export interface GetEstimatedGlucoseValuesOptions {
+    /** Maximum number of readings to retrieve (default: 1) */
+    maxCount?: number;
+    /** Minutes to look back (default: 1440 = 24 hours) */
+    minutes?: number;
+  }
+
+  export interface GlucoseReading {
+    /** Glucose value in mmol/L */
+    mmol: number;
+    /** Glucose value in mg/dL */
+    mgdl: number;
+    /** Trend direction (e.g., "Flat", "SingleUp", "FortyFiveDown") */
+    trend: string;
+    /** Unix timestamp in milliseconds */
+    timestamp: number;
+  }
+
+  export class DexcomClient {
+    constructor(options: DexcomClientOptions);
+
+    /**
+     * Fetch estimated glucose values from Dexcom Share
+     * @param options Optional parameters for the query
+     * @returns Array of glucose readings, most recent first
+     */
+    getEstimatedGlucoseValues(
+      options?: GetEstimatedGlucoseValuesOptions
+    ): Promise<GlucoseReading[]>;
+  }
+}

--- a/packages/functions/src/widgets/registry.ts
+++ b/packages/functions/src/widgets/registry.ts
@@ -4,6 +4,7 @@
  */
 
 import type { WidgetRegistry } from "./types";
+import { bloodSugarUpdater } from "./updaters/blood-sugar";
 import { clockUpdater } from "./updaters/clock";
 
 /**
@@ -11,6 +12,7 @@ import { clockUpdater } from "./updaters/clock";
  * Add new widgets here as they are implemented.
  */
 export const widgetRegistry: WidgetRegistry = {
+  [bloodSugarUpdater.id]: bloodSugarUpdater,
   [clockUpdater.id]: clockUpdater,
 };
 

--- a/packages/functions/src/widgets/updaters/blood-sugar.test.ts
+++ b/packages/functions/src/widgets/updaters/blood-sugar.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  bloodSugarUpdater,
+  classifyRange,
+  mapTrendArrow,
+  isStale,
+  type BloodSugarData,
+} from "./blood-sugar";
+
+// Mock the dexcom-share-api module
+vi.mock("dexcom-share-api", () => ({
+  DexcomClient: vi.fn(),
+}));
+
+// Mock SST Resource
+vi.mock("sst", () => ({
+  Resource: {
+    DexcomUsername: { value: "test-user" },
+    DexcomPassword: { value: "test-pass" },
+  },
+}));
+
+describe("classifyRange", () => {
+  it("classifies urgent low (< 55 mg/dL)", () => {
+    expect(classifyRange(54)).toBe("urgentLow");
+    expect(classifyRange(40)).toBe("urgentLow");
+  });
+
+  it("classifies low (55-69 mg/dL)", () => {
+    expect(classifyRange(55)).toBe("low");
+    expect(classifyRange(69)).toBe("low");
+  });
+
+  it("classifies normal (70-180 mg/dL)", () => {
+    expect(classifyRange(70)).toBe("normal");
+    expect(classifyRange(120)).toBe("normal");
+    expect(classifyRange(180)).toBe("normal");
+  });
+
+  it("classifies high (181-250 mg/dL)", () => {
+    expect(classifyRange(181)).toBe("high");
+    expect(classifyRange(250)).toBe("high");
+  });
+
+  it("classifies very high (> 250 mg/dL)", () => {
+    expect(classifyRange(251)).toBe("veryHigh");
+    expect(classifyRange(400)).toBe("veryHigh");
+  });
+});
+
+describe("mapTrendArrow", () => {
+  it("maps DoubleUp to ↑↑", () => {
+    expect(mapTrendArrow("DoubleUp")).toBe("↑↑");
+  });
+
+  it("maps SingleUp to ↑", () => {
+    expect(mapTrendArrow("SingleUp")).toBe("↑");
+  });
+
+  it("maps FortyFiveUp to ↗", () => {
+    expect(mapTrendArrow("FortyFiveUp")).toBe("↗");
+  });
+
+  it("maps Flat to →", () => {
+    expect(mapTrendArrow("Flat")).toBe("→");
+  });
+
+  it("maps FortyFiveDown to ↘", () => {
+    expect(mapTrendArrow("FortyFiveDown")).toBe("↘");
+  });
+
+  it("maps SingleDown to ↓", () => {
+    expect(mapTrendArrow("SingleDown")).toBe("↓");
+  });
+
+  it("maps DoubleDown to ↓↓", () => {
+    expect(mapTrendArrow("DoubleDown")).toBe("↓↓");
+  });
+
+  it("handles lowercase trends", () => {
+    expect(mapTrendArrow("flat")).toBe("→");
+    expect(mapTrendArrow("fortyfiveup")).toBe("↗");
+  });
+
+  it("returns ? for unknown trends", () => {
+    expect(mapTrendArrow("Unknown")).toBe("?");
+    expect(mapTrendArrow("")).toBe("?");
+  });
+});
+
+describe("isStale", () => {
+  it("returns false for recent timestamps (< 10 minutes)", () => {
+    const now = Date.now();
+    const fiveMinutesAgo = now - 5 * 60 * 1000;
+    expect(isStale(fiveMinutesAgo, now)).toBe(false);
+  });
+
+  it("returns true for old timestamps (> 10 minutes)", () => {
+    const now = Date.now();
+    const fifteenMinutesAgo = now - 15 * 60 * 1000;
+    expect(isStale(fifteenMinutesAgo, now)).toBe(true);
+  });
+
+  it("returns true for exactly 10 minutes", () => {
+    const now = Date.now();
+    const tenMinutesAgo = now - 10 * 60 * 1000;
+    expect(isStale(tenMinutesAgo, now)).toBe(true);
+  });
+
+  it("uses current time by default", () => {
+    const recentTimestamp = Date.now() - 1000; // 1 second ago
+    expect(isStale(recentTimestamp)).toBe(false);
+  });
+});
+
+describe("bloodSugarUpdater", () => {
+  it("has correct id", () => {
+    expect(bloodSugarUpdater.id).toBe("bloodsugar");
+  });
+
+  it("has correct name", () => {
+    expect(bloodSugarUpdater.name).toBe("Blood Sugar Widget");
+  });
+
+  it("has 1 minute schedule", () => {
+    expect(bloodSugarUpdater.schedule).toBe("rate(1 minute)");
+  });
+});
+
+describe("bloodSugarUpdater.update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns properly structured data on success", async () => {
+    const { DexcomClient } = await import("dexcom-share-api");
+
+    const mockReading = {
+      mgdl: 120,
+      mmol: 6.7,
+      trend: "Flat",
+      timestamp: Date.now() - 5 * 60 * 1000,
+    };
+
+    const mockClient = {
+      getEstimatedGlucoseValues: vi.fn().mockResolvedValue([mockReading]),
+    };
+    vi.mocked(DexcomClient).mockImplementation(() => mockClient as never);
+
+    const result = (await bloodSugarUpdater.update()) as BloodSugarData;
+
+    expect(result.glucose).toBe(120);
+    expect(result.glucoseMmol).toBe(6.7);
+    expect(result.trend).toBe("Flat");
+    expect(result.trendArrow).toBe("→");
+    expect(result.rangeStatus).toBe("normal");
+    expect(result.isStale).toBe(false);
+    expect(typeof result.timestamp).toBe("number");
+  });
+
+  it("handles empty readings array", async () => {
+    const { DexcomClient } = await import("dexcom-share-api");
+
+    const mockClient = {
+      getEstimatedGlucoseValues: vi.fn().mockResolvedValue([]),
+    };
+    vi.mocked(DexcomClient).mockImplementation(() => mockClient as never);
+
+    await expect(bloodSugarUpdater.update()).rejects.toThrow(
+      "No glucose readings available"
+    );
+  });
+
+  it("marks stale data correctly", async () => {
+    const { DexcomClient } = await import("dexcom-share-api");
+
+    const mockReading = {
+      mgdl: 100,
+      mmol: 5.6,
+      trend: "Flat",
+      timestamp: Date.now() - 15 * 60 * 1000, // 15 minutes ago
+    };
+
+    const mockClient = {
+      getEstimatedGlucoseValues: vi.fn().mockResolvedValue([mockReading]),
+    };
+    vi.mocked(DexcomClient).mockImplementation(() => mockClient as never);
+
+    const result = (await bloodSugarUpdater.update()) as BloodSugarData;
+    expect(result.isStale).toBe(true);
+  });
+
+  it("calculates delta between readings", async () => {
+    const { DexcomClient } = await import("dexcom-share-api");
+
+    const now = Date.now();
+    const mockReadings = [
+      { mgdl: 130, mmol: 7.2, trend: "SingleUp", timestamp: now },
+      { mgdl: 120, mmol: 6.7, trend: "Flat", timestamp: now - 5 * 60 * 1000 },
+    ];
+
+    const mockClient = {
+      getEstimatedGlucoseValues: vi.fn().mockResolvedValue(mockReadings),
+    };
+    vi.mocked(DexcomClient).mockImplementation(() => mockClient as never);
+
+    const result = (await bloodSugarUpdater.update()) as BloodSugarData;
+    expect(result.delta).toBe(10); // 130 - 120
+  });
+
+  it("returns delta of 0 when only one reading available", async () => {
+    const { DexcomClient } = await import("dexcom-share-api");
+
+    const mockReading = {
+      mgdl: 120,
+      mmol: 6.7,
+      trend: "Flat",
+      timestamp: Date.now(),
+    };
+
+    const mockClient = {
+      getEstimatedGlucoseValues: vi.fn().mockResolvedValue([mockReading]),
+    };
+    vi.mocked(DexcomClient).mockImplementation(() => mockClient as never);
+
+    const result = (await bloodSugarUpdater.update()) as BloodSugarData;
+    expect(result.delta).toBe(0);
+  });
+});

--- a/packages/functions/src/widgets/updaters/blood-sugar.ts
+++ b/packages/functions/src/widgets/updaters/blood-sugar.ts
@@ -1,0 +1,117 @@
+/**
+ * Blood Sugar Widget Updater
+ * Fetches glucose readings from Dexcom Share API.
+ */
+
+import { DexcomClient } from "dexcom-share-api";
+import { Resource } from "sst";
+import type { WidgetUpdater } from "../types";
+
+export interface BloodSugarData {
+  /** Glucose value in mg/dL */
+  glucose: number;
+  /** Glucose value in mmol/L */
+  glucoseMmol: number;
+  /** Raw trend string from Dexcom (e.g., "Flat", "SingleUp") */
+  trend: string;
+  /** Display arrow character (→, ↗, ↑, ↘, ↓, etc.) */
+  trendArrow: string;
+  /** Change from previous reading in mg/dL */
+  delta: number;
+  /** Unix timestamp of reading in milliseconds */
+  timestamp: number;
+  /** True if data is >10 minutes old */
+  isStale: boolean;
+  /** Range classification for display coloring */
+  rangeStatus: "urgentLow" | "low" | "normal" | "high" | "veryHigh";
+}
+
+/** Stale threshold: 10 minutes in milliseconds */
+const STALE_THRESHOLD_MS = 10 * 60 * 1000;
+
+/** Glucose thresholds (mg/dL) */
+const THRESHOLDS = {
+  URGENT_LOW: 55,
+  LOW: 70,
+  HIGH: 180,
+  VERY_HIGH: 250,
+} as const;
+
+/** Trend arrow mappings */
+const TREND_ARROWS: Record<string, string> = {
+  doubleup: "↑↑",
+  singleup: "↑",
+  fortyfiveup: "↗",
+  flat: "→",
+  fortyfivedown: "↘",
+  singledown: "↓",
+  doubledown: "↓↓",
+};
+
+/**
+ * Classify glucose value into range categories.
+ */
+export function classifyRange(
+  mgdl: number
+): BloodSugarData["rangeStatus"] {
+  if (mgdl < THRESHOLDS.URGENT_LOW) return "urgentLow";
+  if (mgdl < THRESHOLDS.LOW) return "low";
+  if (mgdl <= THRESHOLDS.HIGH) return "normal";
+  if (mgdl <= THRESHOLDS.VERY_HIGH) return "high";
+  return "veryHigh";
+}
+
+/**
+ * Map Dexcom trend string to display arrow.
+ */
+export function mapTrendArrow(trend: string): string {
+  return TREND_ARROWS[trend.toLowerCase()] ?? "?";
+}
+
+/**
+ * Check if a reading timestamp is stale (>10 minutes old).
+ */
+export function isStale(timestamp: number, now: number = Date.now()): boolean {
+  return now - timestamp >= STALE_THRESHOLD_MS;
+}
+
+export const bloodSugarUpdater: WidgetUpdater = {
+  id: "bloodsugar",
+  name: "Blood Sugar Widget",
+  schedule: "rate(1 minute)",
+
+  async update(): Promise<BloodSugarData> {
+    const client = new DexcomClient({
+      username: Resource.DexcomUsername.value,
+      password: Resource.DexcomPassword.value,
+      server: "us",
+    });
+
+    // Fetch latest 2 readings for delta calculation
+    const readings = await client.getEstimatedGlucoseValues({
+      maxCount: 2,
+      minutes: 30,
+    });
+
+    if (!readings || readings.length === 0) {
+      throw new Error("No glucose readings available");
+    }
+
+    const latest = readings[0];
+    const previous = readings[1];
+
+    // Calculate delta (change from previous reading)
+    const delta = previous ? latest.mgdl - previous.mgdl : 0;
+
+    return {
+      glucose: latest.mgdl,
+      glucoseMmol: latest.mmol,
+      trend: latest.trend,
+      trendArrow: mapTrendArrow(latest.trend),
+      delta,
+      timestamp: latest.timestamp,
+      isStale: isStale(latest.timestamp),
+      rangeStatus: classifyRange(latest.mgdl),
+    };
+  },
+};

--- a/packages/functions/tsconfig.json
+++ b/packages/functions/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "typeRoots": ["./src/types", "../../node_modules/@types"]
   },
   "include": ["src/**/*", "../../sst-types.d.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@signage/core':
         specifier: workspace:*
         version: link:../core
+      dexcom-share-api:
+        specifier: ^1.0.8
+        version: 1.0.8
       sst:
         specifier: ^3.5.0
         version: 3.17.25
@@ -1357,6 +1360,9 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dexcom-share-api@1.0.8:
+    resolution: {integrity: sha512-305thj1q3NRIfuSIrLk4MNxx4xsbPkRzTTCLTyzWmF7KWamYenvWv5aTPMEwjeTcqiwO0Te4eU073B6PHwrphQ==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1564,6 +1570,9 @@ packages:
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
+  isomorphic-fetch@3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
+
   jmespath@0.16.0:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
     engines: {node: '>= 0.6.0'}
@@ -1634,6 +1643,15 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -1891,6 +1909,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2035,6 +2056,15 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
@@ -3607,6 +3637,12 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dexcom-share-api@1.0.8:
+    dependencies:
+      isomorphic-fetch: 3.0.0
+    transitivePeerDependencies:
+      - encoding
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3894,6 +3930,13 @@ snapshots:
 
   isarray@1.0.0: {}
 
+  isomorphic-fetch@3.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+
   jmespath@0.16.0: {}
 
   jose@4.15.9: {}
@@ -3941,6 +3984,10 @@ snapshots:
   nanoid@3.3.11: {}
 
   negotiator@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.27: {}
 
@@ -4225,6 +4272,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -4343,6 +4392,15 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-fetch@3.6.20: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-typed-array@1.1.20:
     dependencies:

--- a/sst-types.d.ts
+++ b/sst-types.d.ts
@@ -5,6 +5,14 @@
 
 declare module "sst" {
   export interface Resource {
+    DexcomPassword: {
+      type: "sst.sst.Secret";
+      value: string;
+    };
+    DexcomUsername: {
+      type: "sst.sst.Secret";
+      value: string;
+    };
     SignageApi: {
       managementEndpoint: string;
       type: "sst.aws.ApiGatewayWebSocket";

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -19,7 +19,7 @@ export default $config({
     const { api } = await import("./infra/api");
     const { testApi } = await import("./infra/test-api");
     const { web } = await import("./infra/web");
-    const { clockCron, reconcileCron } = await import("./infra/widgets");
+    const { clockCron, reconcileCron, bloodSugarCron } = await import("./infra/widgets");
 
     return {
       websocketUrl: api.url,
@@ -27,6 +27,7 @@ export default $config({
       webUrl: web.url,
       clockCron: clockCron.nodes.rule.name,
       reconcileCron: reconcileCron.nodes.rule.name,
+      bloodSugarCron: bloodSugarCron.nodes.rule.name,
     };
   },
 });


### PR DESCRIPTION
## Summary

- Adds blood sugar widget that fetches glucose readings from Dexcom Share API
- Runs every 1 minute to catch new readings quickly
- Returns structured data (glucose, trend arrow, range status) for terminals to render
- Includes 26 tests for range classification, trend mapping, and API interaction

## Files Changed

| File | Purpose |
|------|---------|
| `packages/functions/src/widgets/updaters/blood-sugar.ts` | Widget updater |
| `packages/functions/src/widgets/updaters/blood-sugar.test.ts` | Tests |
| `infra/secrets.ts` | SST secrets for Dexcom credentials |
| `infra/widgets.ts` | Cron job configuration |

## Test plan

- [x] Unit tests pass (26 new tests)
- [ ] Set secrets after deploy: `sst secret set DexcomUsername/DexcomPassword`
- [ ] Verify data broadcasts to web emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)