### PR TITLE
chore: add .env.example for OSS release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Dexcom Share credentials for blood sugar widget
+DEXCOM_USERNAME=your_dexcom_email
+DEXCOM_PASSWORD=your_dexcom_password


### PR DESCRIPTION
## Summary
- Adds `.env.example` template showing required Dexcom credentials for the blood sugar widget

This completes the OSS preparation work. Most items were already addressed in a previous commit (cf8fbc3).

## Test plan
- [x] Verify .env.example exists and contains expected template
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)