### PR TITLE
Address PR #86 code review feedback

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'no-console': ['warn', { allow: ['log', 'warn', 'error'] }],
     },
   },
   {

--- a/packages/functions/src/oura/types.ts
+++ b/packages/functions/src/oura/types.ts
@@ -63,15 +63,8 @@ export interface OuraUsersList {
   userIds: string[];
 }
 
-/**
- * Readiness data for display rendering
- */
-export interface ReadinessDisplayData {
-  initial: string;
-  score: number | null; // null if no data available
-  isStale: boolean; // true if data is older than 24 hours
-  needsReauth: boolean;
-}
+// Note: ReadinessDisplayData is defined in rendering/readiness-renderer.ts
+// to avoid circular dependencies and keep rendering types together
 
 /**
  * Oura API response for daily readiness

--- a/packages/web/src/pages/Link.tsx
+++ b/packages/web/src/pages/Link.tsx
@@ -79,7 +79,7 @@ export function Link() {
         </p>
       </div>
 
-      <a href="#" style={styles.backLink}>
+      <a href="/#" style={styles.backLink}>
         ← Back to Display
       </a>
     </div>


### PR DESCRIPTION
## Summary

Addresses all code review feedback from PR #86:

### Performance fixes
- **ScanCommand → GetCommand**: Replaced inefficient table scans with direct key lookups for weather cache and Oura user list
- **BatchGetCommand**: Combined N+1 queries into single batch request for fetching user profiles and readiness data (2 users × 2 items = 4 items in one call instead of 5 separate calls)

### Bug fixes
- **needsReauth storage**: Now correctly updates the PROFILE item instead of creating a separate NEEDS_REAUTH item that was never read

### Security improvements (defense-in-depth)
- **OAuth state TTL check**: Added explicit TTL validation since DynamoDB TTL deletion is eventual (can take hours)
- **Host validation**: Added allow-list validation for redirect_uri in both oauth-start and oauth-callback

### Code quality
- **Duplicate interface removed**: Removed ReadinessDisplayData from types.ts (canonical definition is in readiness-renderer.ts)
- **ESLint no-console**: Allow console.log for legitimate Lambda logging
- **Link.tsx back link**: Fixed empty href to properly navigate with hash router

## Test plan
- [x] All 93 tests pass
- [ ] Manual test OAuth flow still works
- [ ] Verify readiness data displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)