### PR TITLE
fix: add 1px separator between treatment and glucose charts

### DIFF
--- a/packages/functions/src/rendering/blood-sugar-renderer.ts
+++ b/packages/functions/src/rendering/blood-sugar-renderer.ts
@@ -21,11 +21,13 @@ const CHART_WIDTH = DISPLAY_WIDTH - 2; // Full width minus margins
 
 // Treatment chart (insulin/carbs) - 1/3 of available chart space
 const TREATMENT_CHART_Y = 28; // After text (5px) + 1px margin
-const TREATMENT_CHART_HEIGHT = 12; // ~1/3 of 35px available
+const TREATMENT_CHART_HEIGHT = 11; // Rows 28-38
+
+// 1px blank separator at row 39
 
 // Glucose chart - 2/3 of available chart space
-const GLUCOSE_CHART_Y = 40; // After treatment chart
-const GLUCOSE_CHART_HEIGHT = 23; // Rows 40-62, ~2/3 of 35px available
+const GLUCOSE_CHART_Y = 40; // After treatment chart + 1px gap
+const GLUCOSE_CHART_HEIGHT = 23; // Rows 40-62
 
 // Split chart: left half = 21h compressed, right half = 3h detailed
 const CHART_LEFT_WIDTH = Math.floor(CHART_WIDTH / 2);


### PR DESCRIPTION
## Summary
- Add 1px blank line (row 39) as visual separator between treatment chart and glucose chart
- Reduce treatment chart from 12px to 11px (rows 28-38)
- Glucose chart remains at 23px (rows 40-62)

## Test plan
- [x] All 166 tests pass
- [x] ASCII debug output verified - row 39 is blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)