### PR TITLE
feat: redesign treatment chart to 36h insulin in 6h buckets

### DIFF
--- a/changes/2026-01-24-2215-treatment-comparison.md
+++ b/changes/2026-01-24-2215-treatment-comparison.md
@@ -1,23 +1,24 @@
-# Treatment Chart 3-Day Insulin Comparison
+# Treatment Chart: 36-Hour Insulin Totals with Daylight Bars
 
 *Date: 2026-01-24 2215*
 
 ## Why
-Glooko treatment data is always delayed, making the 3h "recent" section of the treatment chart perpetually empty. That space can be better used to show actionable insights.
+Glooko treatment data is always delayed, making the 3h "recent" section of the treatment chart perpetually empty. The full treatment chart space can be better used to show actionable insulin insights.
 
 ## How
-Split the treatment chart into two distinct sections:
-- **Left half**: Bar chart showing individual treatments (insulin down, carbs up) for the 21h window (24h-3h ago), matching the glucose chart's left section
-- **Right half**: 3 numbers showing total insulin for the same 21h window across 3 consecutive days:
-  - 72-51h ago (dimmest blue)
-  - 48-27h ago (medium blue)
-  - 24-3h ago (brightest blue)
+Display 36 hours of insulin totals in 6-hour buckets with daylight time markers:
+- **6 buckets**: Each showing total insulin units for a 6-hour period
+  - Bucket 0 (36h-30h ago) → Bucket 5 (6h-0h ago, most recent)
+- **5 daylight bars**: 1px vertical lines between buckets showing time-of-day
+  - Purple (midnight) → Yellow (noon) gradient based on boundary hour
+- **Brightness gradient**: Older buckets are dimmer, newest is brightest blue
 
 ## Key Design Decisions
-- **Same time window comparison**: All 3 periods use the exact same 21h window (offset by 24h each) for apples-to-apples comparison
-- **Insulin only in comparison**: Carbs are shown as bars on the left but the comparison focuses on insulin since it's more actionable for dosing decisions
-- **Brightness for recency**: Older periods are dimmer, newest is brightest - instant visual pattern recognition
+- **6-hour buckets**: Match natural meal/dosing rhythms (breakfast, lunch, dinner, overnight)
+- **Daylight bars**: Provide time context using the same purple→yellow gradient as the glucose chart, making it easy to correlate insulin with time of day
+- **Full-width layout**: Removed the split left/right design to maximize readability
+- **Insulin-only focus**: Carbs removed since insulin is more actionable for dosing decisions
 
 ## What's Next
-- Consider adding carbs comparison below insulin if space permits
-- Could add trend indicator (arrow) if today vs yesterday differs significantly
+- Consider adding a simple trend indicator comparing recent buckets
+- Could show carbs as a secondary row if vertical space permits

--- a/packages/local-dev/src/debug-frame.ts
+++ b/packages/local-dev/src/debug-frame.ts
@@ -26,43 +26,40 @@ const sampleHistory = Array.from({ length: 288 }, (_, i) => ({
   glucose: 120 + Math.sin(i / 20) * 40 + Math.random() * 10,
 }));
 
-// Sample treatment data spanning 3 days for comparison feature
+// Sample treatment data spanning 36 hours in 6-hour buckets
+// Layout: oldest → newest with daylight bars between each bucket
 const HOUR = 60 * 60 * 1000;
 const sampleTreatments: GlookoTreatment[] = [
-  // Period 3: 24h-3h ago (current period, shown as bars on left + number on right)
-  // Total insulin: 8 + 5 + 10 + 7 = 30u
-  { timestamp: now - 5 * HOUR, type: "insulin", value: 8 },
-  { timestamp: now - 5 * HOUR, type: "carbs", value: 60 },
-  { timestamp: now - 8 * HOUR, type: "insulin", value: 5 },
-  { timestamp: now - 12 * HOUR, type: "insulin", value: 10 },
-  { timestamp: now - 12 * HOUR, type: "carbs", value: 80 },
-  { timestamp: now - 18 * HOUR, type: "insulin", value: 7 },
-  { timestamp: now - 18 * HOUR, type: "carbs", value: 45 },
+  // Bucket 5: 6h-0h ago (most recent) - Total: 12u
+  { timestamp: now - 1 * HOUR, type: "insulin", value: 4 },
+  { timestamp: now - 3 * HOUR, type: "insulin", value: 5 },
+  { timestamp: now - 5 * HOUR, type: "insulin", value: 3 },
 
-  // Period 2: 48h-27h ago (yesterday same window)
-  // Total insulin: 6 + 8 + 4 + 7 = 25u
-  { timestamp: now - 30 * HOUR, type: "insulin", value: 6 },
-  { timestamp: now - 30 * HOUR, type: "carbs", value: 55 },
-  { timestamp: now - 33 * HOUR, type: "insulin", value: 8 },
-  { timestamp: now - 36 * HOUR, type: "insulin", value: 4 },
-  { timestamp: now - 36 * HOUR, type: "carbs", value: 70 },
-  { timestamp: now - 42 * HOUR, type: "insulin", value: 7 },
-  { timestamp: now - 42 * HOUR, type: "carbs", value: 50 },
+  // Bucket 4: 12h-6h ago - Total: 8u
+  { timestamp: now - 7 * HOUR, type: "insulin", value: 3 },
+  { timestamp: now - 10 * HOUR, type: "insulin", value: 5 },
 
-  // Period 1: 72h-51h ago (2 days ago same window)
-  // Total insulin: 5 + 9 + 6 = 20u
-  { timestamp: now - 54 * HOUR, type: "insulin", value: 5 },
-  { timestamp: now - 54 * HOUR, type: "carbs", value: 40 },
-  { timestamp: now - 60 * HOUR, type: "insulin", value: 9 },
-  { timestamp: now - 60 * HOUR, type: "carbs", value: 65 },
-  { timestamp: now - 66 * HOUR, type: "insulin", value: 6 },
-  { timestamp: now - 66 * HOUR, type: "carbs", value: 55 },
+  // Bucket 3: 18h-12h ago - Total: 15u
+  { timestamp: now - 13 * HOUR, type: "insulin", value: 6 },
+  { timestamp: now - 16 * HOUR, type: "insulin", value: 9 },
+
+  // Bucket 2: 24h-18h ago - Total: 10u
+  { timestamp: now - 19 * HOUR, type: "insulin", value: 4 },
+  { timestamp: now - 22 * HOUR, type: "insulin", value: 6 },
+
+  // Bucket 1: 30h-24h ago - Total: 7u
+  { timestamp: now - 25 * HOUR, type: "insulin", value: 3 },
+  { timestamp: now - 28 * HOUR, type: "insulin", value: 4 },
+
+  // Bucket 0: 36h-30h ago (oldest) - Total: 5u
+  { timestamp: now - 31 * HOUR, type: "insulin", value: 2 },
+  { timestamp: now - 34 * HOUR, type: "insulin", value: 3 },
 ];
 
 const sampleTreatmentData: TreatmentDisplayData = {
   treatments: sampleTreatments,
-  recentInsulinUnits: 30, // Period 3 total
-  recentCarbsGrams: 185,
+  recentInsulinUnits: 12, // Last 6h total
+  recentCarbsGrams: 0,
   lastFetchedAt: now,
   isStale: false,
 };


### PR DESCRIPTION
## Summary
Replaces the split left/right treatment chart design with a simpler full-width layout showing 36 hours of insulin totals in 6-hour buckets:

- **6 buckets** covering 36h-0h ago (oldest to newest)
- **5 vertical daylight bars** between buckets showing time-of-day context
- **Brightness gradient**: older buckets dimmer, newest brightest
- Uses same purple→yellow daylight gradient as glucose chart

## Design Change
**Before**: Split chart with bars on left, 3-day comparison numbers on right
**After**: Full-width with 6 insulin totals separated by daylight time markers

This provides better insulin dosing context by showing patterns across natural meal/dosing rhythms (breakfast, lunch, dinner, overnight).

## Test plan
- [x] All 171 tests pass
- [x] ASCII debug output shows correct layout
- [ ] Visual verification on Pixoo64 display

🤖 Generated with [Claude Code](https://claude.com/claude-code)