### PR TITLE
feat: add black pixel grid outline to web emulator

### DIFF
--- a/changes/2026-01-24-2304-pixel-grid-outline.md
+++ b/changes/2026-01-24-2304-pixel-grid-outline.md
@@ -1,0 +1,20 @@
+# Black pixel grid outline in web emulator
+
+*Date: 2026-01-24 2304*
+
+## Why
+
+The web emulator's pixel grid was hard to see with faint white lines. Black outlines around each pixel make the grid more visible and give a clearer representation of the Pixoo's discrete LED matrix.
+
+## How
+
+Changed the grid line stroke color from `rgba(255, 255, 255, 0.1)` to solid black (`#000`).
+
+## Key Design Decisions
+
+- Used solid black (`#000`) rather than semi-transparent black for maximum contrast
+- Kept the 1px line width for subtle but visible outlines
+
+## What's Next
+
+None - this is a complete visual enhancement.

--- a/packages/web/src/components/PixelDisplay.tsx
+++ b/packages/web/src/components/PixelDisplay.tsx
@@ -53,8 +53,8 @@ export function PixelDisplay({
     ctx.imageSmoothingEnabled = false;
     ctx.drawImage(tempCanvas, 0, 0, canvas.width, canvas.height);
 
-    // Draw grid lines
-    ctx.strokeStyle = "rgba(255, 255, 255, 0.1)";
+    // Draw grid lines (black pixel outlines)
+    ctx.strokeStyle = "#000";
     ctx.lineWidth = 1;
     for (let x = 0; x <= width; x++) {
       ctx.beginPath();


### PR DESCRIPTION
## Summary

- Changed web emulator grid lines from faint white to solid black for better pixel visibility
- Makes individual pixels more distinct, similar to how the physical Pixoo LED matrix appears

## Test plan

- [x] Web package tests pass (45 tests)
- [ ] Visually verify pixel grid is visible in web emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)