### PR TITLE
feat: combine date and time on single row

### DIFF
--- a/packages/functions/src/rendering/__tests__/clock-renderer.test.ts
+++ b/packages/functions/src/rendering/__tests__/clock-renderer.test.ts
@@ -39,7 +39,7 @@ describe("renderClockRegion", () => {
     renderClockRegion(frame, "America/Los_Angeles");
 
     // Combined date+time should span most of the width at row 1
-    // Format: "SAT JAN 24 2:30" (16 chars = ~63 pixels)
+    // Format: "SAT JAN 24 2:30" (15 chars ≈ 59 pixels)
     let pixelCount = 0;
     for (let x = 0; x < 64; x++) {
       const pixel = getPixel(frame, x, 4); // Middle of text (row 1 + 3)

--- a/packages/functions/src/rendering/clock-renderer.ts
+++ b/packages/functions/src/rendering/clock-renderer.ts
@@ -121,7 +121,7 @@ export function renderClockRegion(
   const dateTimeX = centerXInBounds(dateTimeStr, startX, endX);
   drawText(frame, dateTimeStr, dateTimeX, startY + 1, COLORS.clockTime, startY, endY);
 
-  // Rows 18-25: Sunlight gradient band with temperature overlay
+  // Sunlight gradient band with temperature overlay
   renderSunlightBand(frame, currentHour24, weather, startX, endX);
 }
 


### PR DESCRIPTION
## Summary
- Merges separate date and time rows into single line format: "SAT JAN 24 11:09"
- Drops the year to save horizontal space
- Reclaims vertical space between datetime and sunlight band

## Test plan
- [x] Clock renderer tests pass (9 tests)
- [ ] Visual verification on Pixoo display or web emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)