### PR TITLE
feat: add Glooko data latency indicator to treatment chart

### DIFF
--- a/changes/2026-01-25-0723-glooko-latency-indicator.md
+++ b/changes/2026-01-25-0723-glooko-latency-indicator.md
@@ -1,0 +1,21 @@
+# Glooko Data Latency Indicator
+
+*Date: 2026-01-25 0723*
+
+## Why
+Glooko treatment data is always delayed (typically 2-3 hours). Without knowing when data was last fetched, it's unclear whether today's (or yesterday's) insulin total is complete or partial.
+
+## How
+Added a latency indicator to the right of the treatment chart's "today" insulin total:
+- Shows time since last Glooko data fetch
+- Format: "Xm" for < 60 minutes, "Xh" (ceil to nearest hour) for >= 60 minutes
+- Uses same white/grey color as the clock time indicator for consistency
+
+## Key Design Decisions
+- **Same style as glucose latency**: Matches the "5m" format used for glucose data freshness
+- **Hours rounded up**: At >= 60m, we ceil to the nearest hour (e.g., 65m shows as "2h") for simpler display
+- **Right-aligned**: Placed after the "today" number since it represents the freshness of that data
+
+## What's Next
+- Monitor if the indicator is useful in practice
+- Consider color-coding (e.g., yellow/red) if latency exceeds certain thresholds

--- a/packages/functions/src/rendering/blood-sugar-renderer.ts
+++ b/packages/functions/src/rendering/blood-sugar-renderer.ts
@@ -350,15 +350,28 @@ function renderTreatmentChart(
 
   const dayStrs = dayTotals.map(formatInsulin);
 
-  // Calculate total width needed
+  // Format latency indicator (time since last Glooko data)
+  const formatLatency = (lastFetchedAt: number): string => {
+    const msAgo = now - lastFetchedAt;
+    const minsAgo = Math.floor(msAgo / (60 * 1000));
+    if (minsAgo < 60) {
+      return `${minsAgo}m`;
+    }
+    const hoursAgo = Math.ceil(minsAgo / 60);
+    return `${hoursAgo}h`;
+  };
+  const latencyStr = formatLatency(treatments.lastFetchedAt);
+
+  // Calculate total width needed (4 day totals + latency)
   const dayWidths = dayStrs.map(s => measureTinyText(s));
-  const totalTextWidth = dayWidths.reduce((a, b) => a + b, 0);
+  const latencyWidth = measureTinyText(latencyStr);
+  const totalTextWidth = dayWidths.reduce((a, b) => a + b, 0) + latencyWidth;
 
   // Available width for the treatment chart
   const availableWidth = CHART_WIDTH;
 
-  // Calculate spacing between numbers (no vertical bars)
-  const numGaps = 3; // 3 gaps between 4 numbers
+  // Calculate spacing between numbers (3 gaps between 4 day totals + 1 gap before latency)
+  const numGaps = 4; // 4 gaps total
   const extraSpace = availableWidth - totalTextWidth;
   const spacing = Math.max(2, Math.floor(extraSpace / numGaps));
 
@@ -385,13 +398,11 @@ function renderTreatmentChart(
   for (let i = 0; i < 4; i++) {
     const color = getDayColor(i);
     drawTinyText(frame, dayStrs[i], x, textY, color);
-    x += dayWidths[i];
-
-    // Add spacing after each number except the last
-    if (i < 3) {
-      x += spacing;
-    }
+    x += dayWidths[i] + spacing;
   }
+
+  // Draw latency indicator (same color as clock time - white/grey)
+  drawTinyText(frame, latencyStr, x, textY, COLORS.clockTime);
 }
 
 /**


### PR DESCRIPTION
## Summary
Show time since last Glooko data fetch next to the "today" insulin total, helping users understand if the numbers are complete or partial.

- Format: "Xm" for < 60 minutes, "Xh" (ceil) for >= 60 minutes
- Uses same white color as clock time for consistency
- Placed after the 4-day totals row (e.g., "28 35 42 18 3h")

## Why
Glooko treatment data is always delayed (typically 2-3 hours). Without knowing when data was last fetched, it's unclear whether today's or yesterday's insulin total is complete.

## Test plan
- [x] All 233 tests pass
- [x] Lint passes
- [ ] Visual verification on Pixoo64 display

🤖 Generated with [Claude Code](https://claude.com/claude-code)