### PR TITLE
fix: restore color contrast between date and time

### DIFF
--- a/packages/functions/src/rendering/__tests__/clock-renderer.test.ts
+++ b/packages/functions/src/rendering/__tests__/clock-renderer.test.ts
@@ -51,6 +51,34 @@ describe("renderClockRegion", () => {
     expect(pixelCount).toBeGreaterThan(15);
   });
 
+  it("renders date in dim color and time in bright color", () => {
+    const frame = createSolidFrame(64, 64);
+    renderClockRegion(frame, "America/Los_Angeles");
+
+    // Scan row 4 (middle of text) for color differences
+    // Date portion uses clockSecondary (100, 100, 100)
+    // Time portion uses clockTime (255, 255, 255)
+    let foundDimPixel = false;
+    let foundBrightPixel = false;
+
+    for (let x = 0; x < 64; x++) {
+      const pixel = getPixel(frame, x, 4);
+      if (pixel) {
+        // Dim gray (date)
+        if (pixel.r === 100 && pixel.g === 100 && pixel.b === 100) {
+          foundDimPixel = true;
+        }
+        // Bright white (time)
+        if (pixel.r === 255 && pixel.g === 255 && pixel.b === 255) {
+          foundBrightPixel = true;
+        }
+      }
+    }
+
+    expect(foundDimPixel).toBe(true);
+    expect(foundBrightPixel).toBe(true);
+  });
+
   it("renders sunlight band", () => {
     const frame = createSolidFrame(64, 64);
     renderClockRegion(frame, "America/Los_Angeles");

--- a/packages/functions/src/rendering/clock-renderer.ts
+++ b/packages/functions/src/rendering/clock-renderer.ts
@@ -121,7 +121,7 @@ export function renderClockRegion(
   // Draw date (dimmer) and time (brighter) with different colors
   const dateTimeX = centerXInBounds(dateTimeStr, startX, endX);
   const dateWidth = measureText(dateStr);
-  drawText(frame, dateStr, dateTimeX, startY + 1, COLORS.clockAmPm, startY, endY);
+  drawText(frame, dateStr, dateTimeX, startY + 1, COLORS.clockSecondary, startY, endY);
   drawText(frame, timeStr, dateTimeX + dateWidth + 1, startY + 1, COLORS.clockTime, startY, endY);
 
   // Sunlight gradient band with temperature overlay

--- a/packages/functions/src/rendering/colors.ts
+++ b/packages/functions/src/rendering/colors.ts
@@ -8,7 +8,7 @@ export const COLORS = {
   // Clock colors
   clockHeader: { r: 0, g: 200, b: 255 } as RGB,
   clockTime: { r: 255, g: 255, b: 255 } as RGB,
-  clockAmPm: { r: 100, g: 100, b: 100 } as RGB,
+  clockSecondary: { r: 100, g: 100, b: 100 } as RGB, // Date, AM/PM, and other secondary text
 
   // Blood sugar colors by range
   urgentLow: { r: 255, g: 0, b: 0 } as RGB,


### PR DESCRIPTION
## Summary
- Draw date portion (SAT JAN 24) in dimmer `clockAmPm` color
- Draw time portion (11:09) in brighter `clockTime` color
- Restores the visual hierarchy from the original two-row design

## Test plan
- [x] Clock renderer tests pass (9 tests)
- [ ] Visual verification on display

🤖 Generated with [Claude Code](https://claude.com/claude-code)