### PR TITLE
fix: show time since last insulin delivery, not last data fetch

### DIFF
--- a/packages/functions/src/rendering/blood-sugar-renderer.ts
+++ b/packages/functions/src/rendering/blood-sugar-renderer.ts
@@ -350,9 +350,16 @@ function renderTreatmentChart(
 
   const dayStrs = dayTotals.map(formatInsulin);
 
-  // Format latency indicator (time since last Glooko data)
-  const formatLatency = (lastFetchedAt: number): string => {
-    const msAgo = now - lastFetchedAt;
+  // Find the most recent insulin treatment timestamp
+  const insulinTreatments = treatmentList.filter(t => t.type === "insulin");
+  const lastInsulinTime = insulinTreatments.length > 0
+    ? Math.max(...insulinTreatments.map(t => t.timestamp))
+    : 0;
+
+  // Format latency indicator (time since last known insulin delivery)
+  const formatLatency = (lastTimestamp: number): string => {
+    if (lastTimestamp === 0) return "?";
+    const msAgo = now - lastTimestamp;
     const minsAgo = Math.floor(msAgo / (60 * 1000));
     if (minsAgo < 60) {
       return `${minsAgo}m`;
@@ -360,7 +367,7 @@ function renderTreatmentChart(
     const hoursAgo = Math.ceil(minsAgo / 60);
     return `${hoursAgo}h`;
   };
-  const latencyStr = formatLatency(treatments.lastFetchedAt);
+  const latencyStr = formatLatency(lastInsulinTime);
 
   // Calculate total width needed (4 day totals + latency)
   const dayWidths = dayStrs.map(s => measureTinyText(s));


### PR DESCRIPTION
## Summary
- Fixed the Glooko latency indicator to show time since last **known insulin delivery** rather than time since last API call
- Now uses max timestamp from insulin treatments instead of `lastFetchedAt`
- Shows "?" if no insulin treatments exist

## Why
The previous implementation showed when we last fetched Glooko data, but this doesn't tell the user how fresh the actual insulin totals are. The meaningful metric is when insulin was last delivered, as that indicates how complete today's total is.

## Test plan
- [x] All 233 tests pass
- [x] Lint passes
- [ ] Verify on web emulator that latency now shows plausible times

---
Generated with [Claude Code](https://claude.ai/code)