### PR TITLE
fix: adjust trend arrow pixel shapes

### DIFF
--- a/changes/2026-01-25-0022-trend-arrow-shapes.md
+++ b/changes/2026-01-25-0022-trend-arrow-shapes.md
@@ -1,0 +1,24 @@
+# Adjust trend arrow pixel shapes
+
+*Date: 2026-01-25 0022*
+
+## Why
+
+The trend arrows needed visual adjustments for better clarity on the 64x64 LED display.
+
+## How
+
+Updated the 5x5 bitmap definitions for trend arrows:
+
+- **doubleup/doubledown**: Added corner pixels on the middle row for visual balance
+- **fortyfiveup/fortyfivedown**: Shifted arrowhead to `.####`, added notch pixel, removed far corner
+- **flat**: Changed horizontal line from `#####` to `.####`
+
+## Key Design Decisions
+
+- Maintained 5x5 pixel grid to match existing font height
+- Changes improve arrow readability at small display sizes
+
+## What's Next
+
+None - visual adjustment complete.

--- a/packages/functions/src/rendering/blood-sugar-renderer.ts
+++ b/packages/functions/src/rendering/blood-sugar-renderer.ts
@@ -76,7 +76,7 @@ const TREND_ARROWS: Record<string, number[]> = {
   doubleup: [
     0b00100,
     0b01010,
-    0b00000,
+    0b10001,
     0b00100,
     0b01010,
   ],
@@ -90,27 +90,27 @@ const TREND_ARROWS: Record<string, number[]> = {
   ],
   // ↗ Diagonal up-right
   fortyfiveup: [
-    0b00111,
+    0b01111,
     0b00011,
     0b00101,
-    0b01000,
-    0b10000,
+    0b01001,
+    0b00000,
   ],
   // → Flat/steady
   flat: [
     0b00100,
     0b00010,
-    0b11111,
+    0b01111,
     0b00010,
     0b00100,
   ],
   // ↘ Diagonal down-right
   fortyfivedown: [
-    0b10000,
-    0b01000,
+    0b00000,
+    0b01001,
     0b00101,
     0b00011,
-    0b00111,
+    0b01111,
   ],
   // ↓ Single down arrow
   singledown: [
@@ -124,7 +124,7 @@ const TREND_ARROWS: Record<string, number[]> = {
   doubledown: [
     0b01010,
     0b00100,
-    0b00000,
+    0b10001,
     0b01010,
     0b00100,
   ],


### PR DESCRIPTION
## Summary
- Adjust 5x5 bitmap definitions for trend arrows for better visual clarity
- doubleup/doubledown: add corner pixels on middle row
- fortyfiveup/fortyfivedown: shift arrowhead, add notch, remove far corner  
- flat: change horizontal line from ##### to .####

## Test plan
- [x] Tests pass (234 tests)
- [ ] Visual inspection on Pixoo64 display

🤖 Generated with [Claude Code](https://claude.com/claude-code)