### PR TITLE
fix: tweak trend arrow shapes

### DIFF
--- a/changes/2026-01-25-0030-trend-arrow-tweaks.md
+++ b/changes/2026-01-25-0030-trend-arrow-tweaks.md
@@ -1,22 +1,31 @@
-# Tweak trend arrow shapes
+# Tweak trend arrows and layout
 
 *Date: 2026-01-25 0030*
 
 ## Why
 
-Follow-up adjustments to trend arrow pixels after visual testing.
+Follow-up adjustments to trend arrow pixels and display layout for better visual clarity.
 
 ## How
 
-Restored corner pixels and full horizontal line that were previously removed:
+**Arrow tweaks:**
+- fortyfiveup/fortyfivedown: Restored far corner pixel (`#....`)
+- flat: Restored full horizontal line (`#####`)
 
-- **fortyfiveup/fortyfivedown**: Restored far corner pixel (`#....`)
-- **flat**: Restored full horizontal line (`#####`)
+**Layout reorganization:**
+- Swapped glucose reading and insulin totals so glucose is right above sparkline
+- Equally spaced 4 sections above sparkline:
+  - Rows 3-7: Date/time
+  - Rows 12-19: Weather band
+  - Rows 23-27: Insulin totals
+  - Rows 32-36: Glucose reading
+  - Rows 40-62: Sparkline (unchanged)
 
 ## Key Design Decisions
 
-- Keep diagonal arrows with full corner-to-corner span for better directionality
-- Full horizontal line on flat arrow improves visibility
+- Glucose reading adjacent to sparkline provides better visual context
+- Equal spacing creates cleaner visual hierarchy
+- Diagonal arrows with full corner-to-corner span for better directionality
 
 ## What's Next
 

--- a/packages/functions/src/rendering/__tests__/clock-renderer.test.ts
+++ b/packages/functions/src/rendering/__tests__/clock-renderer.test.ts
@@ -204,8 +204,8 @@ describe("renderClockRegion", () => {
 
     renderClockRegion(frame, "America/Los_Angeles", rainyWeather);
 
-    // Bottom row of band (row 20, compact layout) should have rain indicator (blue)
-    const precipPixel = getPixel(frame, 20, 20);
+    // Bottom row of band (row 19, compact layout) should have rain indicator (blue)
+    const precipPixel = getPixel(frame, 20, 19);
     expect(precipPixel).not.toBeNull();
     // Rain should have blue component
     expect(precipPixel!.b).toBeGreaterThan(precipPixel!.r);

--- a/packages/functions/src/rendering/__tests__/frame-composer.test.ts
+++ b/packages/functions/src/rendering/__tests__/frame-composer.test.ts
@@ -63,11 +63,11 @@ describe("generateCompositeFrame", () => {
 
     const frame = generateCompositeFrame(data);
 
-    // Check for pixels in blood sugar region (compact layout, rows 21-63)
-    // Text row is at 22-26
+    // Check for pixels in blood sugar region
+    // Glucose reading is now at rows 32-36 (right above sparkline)
     let hasBloodSugarPixels = false;
     for (let x = 0; x < 64; x++) {
-      const pixel = getPixel(frame, x, 24); // Middle of text row (22-26)
+      const pixel = getPixel(frame, x, 34); // Middle of text row (32-36)
       if (pixel && (pixel.r > 0 || pixel.g > 0 || pixel.b > 0)) {
         hasBloodSugarPixels = true;
         break;
@@ -83,10 +83,11 @@ describe("generateCompositeFrame", () => {
 
     const frame = generateCompositeFrame(data);
 
-    // Should show error text in blood sugar region (starts at row 21)
+    // Should show error text in blood sugar region
+    // Glucose reading (or error) is at rows 32-36
     let hasBottomPixels = false;
     for (let x = 0; x < 64; x++) {
-      for (let y = 22; y < 28; y++) { // Check text row area (22-26)
+      for (let y = 32; y < 38; y++) { // Check text row area (32-36)
         const pixel = getPixel(frame, x, y);
         if (pixel && (pixel.r > 0 || pixel.g > 0 || pixel.b > 0)) {
           hasBottomPixels = true;
@@ -185,11 +186,11 @@ describe("generateCompositeFrame", () => {
 
     const frame = generateCompositeFrame(data);
 
-    // Treatment chart is rows 28-38
+    // Treatment chart is now at rows 23-27
     // Should have blue pixels for insulin numbers (4-day totals)
     let hasBluePixels = false;
     for (let x = 0; x < 64; x++) {
-      for (let y = 28; y < 39; y++) {
+      for (let y = 23; y < 28; y++) {
         const pixel = getPixel(frame, x, y);
         // Insulin numbers are blue (b > r)
         if (pixel && pixel.b > pixel.r && pixel.b > 30) {
@@ -226,10 +227,10 @@ describe("generateCompositeFrame", () => {
 
     const frame = generateCompositeFrame(data);
 
-    // Treatment chart should NOT have any significant pixels when stale
+    // Treatment chart (rows 23-27) should NOT have any significant pixels when stale
     let hasTreatmentPixels = false;
     for (let x = 0; x < 64; x++) {
-      for (let y = 28; y < 39; y++) {
+      for (let y = 23; y < 28; y++) {
         const pixel = getPixel(frame, x, y);
         // Check for any bright pixels (blue numbers)
         if (pixel && (pixel.b > 50 || pixel.r > 80)) {

--- a/packages/functions/src/rendering/blood-sugar-renderer.ts
+++ b/packages/functions/src/rendering/blood-sugar-renderer.ts
@@ -13,20 +13,21 @@ import type { TreatmentDisplayData } from "../glooko/types.js";
 const BG_REGION_START = 21;
 const BG_REGION_END = 63;
 
-// Layout configuration - text on top, treatment chart, then glucose chart
-const TEXT_ROW = 22; // 1px below divider at row 21
+// Layout configuration - equal spacing above sparkline
+// Sections: date/time (rows 3-7), weather (12-19), insulin (23-27), glucose (32-36)
 const TEXT_MARGIN = 1; // Left/right margin for text
 const CHART_X = 1;
 const CHART_WIDTH = DISPLAY_WIDTH - 2; // Full width minus margins
 
-// Treatment chart (insulin/carbs) - 1/3 of available chart space
-const TREATMENT_CHART_Y = 28; // After text (5px) + 1px margin
-const TREATMENT_CHART_HEIGHT = 11; // Rows 28-38
+// Treatment chart (insulin totals) - above glucose reading
+const TREATMENT_CHART_Y = 23;
+const TREATMENT_CHART_HEIGHT = 5; // Rows 23-27
 
-// 1px blank separator at row 39
+// Glucose reading - right above sparkline
+const TEXT_ROW = 32; // Rows 32-36
 
-// Glucose chart - 2/3 of available chart space
-const GLUCOSE_CHART_Y = 40; // After treatment chart + 1px gap
+// Glucose sparkline chart
+const GLUCOSE_CHART_Y = 40;
 const GLUCOSE_CHART_HEIGHT = 23; // Rows 40-62
 
 // Split chart: left half = 21h compressed, right half = 3h detailed

--- a/packages/functions/src/rendering/clock-renderer.ts
+++ b/packages/functions/src/rendering/clock-renderer.ts
@@ -22,7 +22,7 @@ export interface ClockRegionBounds {
 }
 
 // Sunlight band configuration (compact layout)
-const BAND_Y = 13; // Start row for the band (moved up from 18)
+const BAND_Y = 12; // Start row for the band
 const BAND_HEIGHT = 8; // Height of the sunlight band
 const BAND_MARGIN = 1; // Left/right margin
 
@@ -121,8 +121,8 @@ export function renderClockRegion(
   // Draw date (dimmer) and time (brighter) with different colors
   const dateTimeX = centerXInBounds(dateTimeStr, startX, endX);
   const dateWidth = measureText(dateStr);
-  drawText(frame, dateStr, dateTimeX, startY + 1, COLORS.clockSecondary, startY, endY);
-  drawText(frame, timeStr, dateTimeX + dateWidth + 1, startY + 1, COLORS.clockTime, startY, endY);
+  drawText(frame, dateStr, dateTimeX, startY + 3, COLORS.clockSecondary, startY, endY);
+  drawText(frame, timeStr, dateTimeX + dateWidth + 1, startY + 3, COLORS.clockTime, startY, endY);
 
   // Sunlight gradient band with temperature overlay
   renderSunlightBand(frame, currentHour24, weather, startX, endX);

--- a/packages/functions/src/rendering/frame-composer.ts
+++ b/packages/functions/src/rendering/frame-composer.ts
@@ -1,14 +1,16 @@
 /**
  * Frame composer - combines all widgets into a single frame
  *
- * Layout (64x64):
+ * Layout (64x64) - 4 equally-spaced sections above sparkline:
  * ┌───────────────────────────────────────┐
- * │           10:45                       │  row 1-5
- * │        SUN JAN 19 2026                │  row 7-11
- * │      [weather/sunlight band]          │  rows 13-20
- * ├───────────────────────────────────────┤  row 21
- * │  → 142 +5 2m                          │  row 22-26
- * │     [treatment chart - insulin/carbs] │  rows 28-39 (12px)
+ * │        SUN JAN 19 10:45               │  rows 3-7
+ * │                                       │  gap
+ * │      [weather/sunlight band]          │  rows 12-19
+ * │                                       │  gap
+ * │        12  24  36  48  5m             │  rows 23-27 (insulin totals)
+ * │                                       │  gap
+ * │  → 142 +5 2m                          │  rows 32-36 (glucose reading)
+ * │                                       │  gap
  * │     [glucose sparkline chart]         │  rows 40-62 (23px)
  * └───────────────────────────────────────┘
  */


### PR DESCRIPTION
## Summary
- Restore far corner pixels on fortyfiveup/fortyfivedown arrows
- Restore full horizontal line on flat arrow (`#####`)
- **Swap glucose/insulin layout**: glucose reading now right above sparkline
- **Equal vertical spacing** for 4 sections above sparkline:
  - Rows 3-7: Date/time
  - Rows 12-19: Weather band
  - Rows 23-27: Insulin totals  
  - Rows 32-36: Glucose reading
  - Rows 40-62: Sparkline

Follow-up to #123.

## Test plan
- [x] Tests pass (234 tests)
- [ ] Visual inspection on Pixoo64 display

🤖 Generated with [Claude Code](https://claude.com/claude-code)