### PR TITLE
fix: exclude daily insulin totals from treatment cache

### DIFF
--- a/packages/functions/src/glooko/scraper.ts
+++ b/packages/functions/src/glooko/scraper.ts
@@ -807,9 +807,10 @@ export function parseCsvFiles(csvFiles: ExtractedCsv[]): GlookoTreatment[] {
       treatments.push(...parseCarbsCsv(content, fileName));
     } else if (lowerName.includes("bolus")) {
       treatments.push(...parseBolusCsv(content, fileName));
-    } else if (lowerName.includes("insulin") && !lowerName.includes("basal") && !lowerName.includes("insulin_data")) {
-      // Note: insulin_data files contain daily TOTALS, not individual doses
+    } else if (lowerName.includes("insulin") && !lowerName.includes("basal") && !lowerName.match(/insulin_data\/insulin_data_\d+\.csv/)) {
+      // Note: insulin_data/insulin_data_N.csv files contain daily TOTALS, not individual doses
       // We get individual boluses from bolus_data files instead
+      // But manual_insulin_data files ARE individual doses and should be parsed
       treatments.push(...parseInsulinCsv(content, fileName));
     }
     // Skip other files (cgm_data, bg_data, basal_data, insulin_data, etc.)


### PR DESCRIPTION
## Summary

The `insulin_data` files from Glooko contain running daily totals (recorded at ~23:55 each day), not individual insulin doses. These were being included in the treatment cache, causing double-counting when calculating daily insulin totals for the display.

**Before:** Display showed inflated totals (e.g., Jan 24 showed 21u instead of ~10u)
**After:** Display will show correct totals from individual boluses only

## Root Cause

In `parseCsvFiles()`, the condition:
```typescript
lowerName.includes("insulin") && !lowerName.includes("basal")
```
matched `insulin_data_1.csv` which contains daily summary records, not individual doses.

## Fix

~~Added `!lowerName.includes("insulin_data")` to exclude the daily summary file.~~

**Updated:** After Codex review, changed to use a specific regex pattern `/insulin_data\/insulin_data_\d+\.csv/` that only excludes the daily summary files without accidentally excluding `manual_insulin_data` files (which contain individual MDI doses).

Individual boluses are captured from:
- `bolus_data` files (pump boluses)
- `manual_insulin_data` files (pen/syringe injections)

## Test plan

- [x] All 264 tests pass
- [ ] Deploy and trigger Glooko re-import
- [ ] Verify display shows correct daily totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)