### PR TITLE
fix: increase insulin query limit to fetch all days

### DIFF
--- a/changes/2026-01-29-2250-insulin-query-limit.md
+++ b/changes/2026-01-29-2250-insulin-query-limit.md
@@ -1,0 +1,24 @@
+# Fix: Insulin Daily Totals Query Limit
+
+*Date: 2026-01-29 2250*
+
+## Why
+
+The display was showing incorrect insulin totals for days older than 2-3 days. Investigation revealed that Glooko exports running totals throughout each day (potentially 4-8 records per day), but the query was limited to 20 records.
+
+With `Limit: 20` and ~4+ records per day, only the most recent ~5 days of data was being fetched. Older days (5 days ago) would fall back to bolus-only values instead of the full daily totals.
+
+## How
+
+Increased the DynamoDB query limit from 20 to 100 in `fetchDailyInsulinTotals()`. This ensures at least 14 days of data is retrieved even with multiple running total records per day.
+
+## Key Design Decisions
+
+- **Limit: 100** provides comfortable margin for 14-day exports with 7+ records/day
+- Keep existing "max value per date" logic to handle running totals correctly
+- No pagination needed since 100 records is well under DynamoDB's 1MB limit
+
+## What's Next
+
+- Monitor Lambda logs to verify daily totals now include all expected dates
+- Consider adding pagination if export window increases significantly

--- a/packages/functions/src/compositor.ts
+++ b/packages/functions/src/compositor.ts
@@ -278,7 +278,7 @@ async function fetchDailyInsulinTotals(): Promise<Record<string, number>> {
           ":pk": "USER#primary#DAILY_INSULIN",
         },
         ScanIndexForward: false, // Most recent first
-        Limit: 20, // Last ~20 records covers multiple days with duplicates
+        Limit: 100, // Glooko exports running totals (~4-8 records/day), need enough for 14 days
       })
     );
 


### PR DESCRIPTION
## Summary

- Increase DynamoDB query limit from 20 to 100 for DAILY_INSULIN records
- Fixes bug where insulin totals for days 5+ ago showed bolus-only values

## Problem

The display was showing incorrect insulin totals:
- **Expected**: 18, 12, 15, 16, 12 (from Glooko)
- **Actual**: 9, 5, 8, 16, 12

The first 3 values were bolus-only (roughly half of total), while the last 2 were correct.

## Root Cause

Glooko exports running totals throughout each day (~4-8 records per day). With `Limit: 20`, only ~5 days of data was fetched. Older days fell back to bolus-only calculation instead of using the pre-calculated daily totals.

## Test plan

- [ ] Deploy and verify Lambda logs show all 5 expected dates in `dailyInsulinTotals`
- [ ] Verify display shows correct totals matching Glooko screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)