### PR TITLE
Fix ZIP extraction dropping all files except first

### DIFF
--- a/changes/2026-03-07-0136-fix-zip-data-descriptor.md
+++ b/changes/2026-03-07-0136-fix-zip-data-descriptor.md
@@ -1,0 +1,19 @@
+# Fix ZIP extraction missing files due to data descriptors
+
+*Date: 2026-03-07 0136*
+
+## Why
+The Glooko scraper was only extracting the first CSV file (cgm_data_1.csv) from the ZIP export. All other files (bolus, insulin, basal, etc.) were silently dropped, causing daily insulin history to show 0 for the last 4+ days.
+
+## How
+The ZIP parser read `compressedSize` from local file headers to advance through the archive. Glooko's ZIP uses data descriptors (general purpose bit flag bit 3), which sets local header sizes to `0xFFFFFFFF`. The parser treated this as the actual compressed size, jumped past the buffer after the first file, and exited.
+
+Fixed by parsing the central directory at the end of the ZIP, which always has accurate sizes regardless of data descriptors. Falls back to the old local-header approach for ZIPs without a central directory.
+
+## Key Design Decisions
+- Central directory parsing is the primary path since it's always reliable
+- Local file header fallback preserved for backward compatibility with simple ZIPs
+- No external ZIP library added — the manual parser handles all cases Glooko produces
+
+## What's Next
+- Monitor next scraper run to confirm all CSV file types are extracted

--- a/packages/functions/src/glooko/scraper.test.ts
+++ b/packages/functions/src/glooko/scraper.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for Glooko CSV parser
+ * Tests for Glooko CSV parser and ZIP extraction
  */
 
 import { describe, it, expect } from "vitest";
-import { parseCsv } from "./scraper.js";
+import { parseCsv, extractCsvFilesFromZip } from "./scraper.js";
+import { deflateRawSync } from "zlib";
 
 describe("parseCsv", () => {
   it("parses insulin treatments from CSV", () => {
@@ -147,5 +148,198 @@ invalid-date,5.0,
 
     expect(treatments).toHaveLength(1);
     expect(treatments[0].value).toBe(3.0);
+  });
+});
+
+/**
+ * Helper to build a ZIP local file entry with optional data descriptor
+ */
+function buildZipEntry(
+  fileName: string,
+  content: string,
+  options: { useDataDescriptor?: boolean } = {}
+): Buffer {
+  const { useDataDescriptor = false } = options;
+  const fileNameBuf = Buffer.from(fileName, "utf-8");
+  const uncompressedBuf = Buffer.from(content, "utf-8");
+  const compressedBuf = deflateRawSync(uncompressedBuf);
+
+  const generalPurposeFlags = useDataDescriptor ? 0x0008 : 0x0000;
+  const headerCompressedSize = useDataDescriptor ? 0xffffffff : compressedBuf.length;
+  const headerUncompressedSize = useDataDescriptor ? 0xffffffff : uncompressedBuf.length;
+
+  // Local file header (30 bytes + fileName)
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(0x04034b50, 0); // signature
+  header.writeUInt16LE(20, 4); // version needed
+  header.writeUInt16LE(generalPurposeFlags, 6);
+  header.writeUInt16LE(8, 8); // compression method: deflate
+  header.writeUInt16LE(0, 10); // mod time
+  header.writeUInt16LE(0, 12); // mod date
+  header.writeUInt32LE(0, 14); // crc32 (placeholder)
+  header.writeUInt32LE(headerCompressedSize, 18);
+  header.writeUInt32LE(headerUncompressedSize, 22);
+  header.writeUInt16LE(fileNameBuf.length, 26);
+  header.writeUInt16LE(0, 28); // extra field length
+
+  const parts = [header, fileNameBuf, compressedBuf];
+
+  if (useDataDescriptor) {
+    // Data descriptor: signature + crc32 + compressed size + uncompressed size
+    const descriptor = Buffer.alloc(16);
+    descriptor.writeUInt32LE(0x08074b50, 0); // data descriptor signature
+    descriptor.writeUInt32LE(0, 4); // crc32 (placeholder)
+    descriptor.writeUInt32LE(compressedBuf.length, 8);
+    descriptor.writeUInt32LE(uncompressedBuf.length, 12);
+    parts.push(descriptor);
+  }
+
+  return Buffer.concat(parts);
+}
+
+/**
+ * Helper to build a ZIP central directory + EOCD for given entries
+ */
+function buildZipCentralDirectory(
+  entries: Array<{ fileName: string; content: string; localHeaderOffset: number }>
+): Buffer {
+  const centralEntries: Buffer[] = [];
+  let centralDirSize = 0;
+
+  for (const entry of entries) {
+    const fileNameBuf = Buffer.from(entry.fileName, "utf-8");
+    const uncompressedBuf = Buffer.from(entry.content, "utf-8");
+    const compressedBuf = deflateRawSync(uncompressedBuf);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0); // central directory signature
+    centralHeader.writeUInt16LE(20, 4); // version made by
+    centralHeader.writeUInt16LE(20, 6); // version needed
+    centralHeader.writeUInt16LE(0, 8); // flags
+    centralHeader.writeUInt16LE(8, 10); // compression method
+    centralHeader.writeUInt16LE(0, 12); // mod time
+    centralHeader.writeUInt16LE(0, 14); // mod date
+    centralHeader.writeUInt32LE(0, 16); // crc32
+    centralHeader.writeUInt32LE(compressedBuf.length, 20); // compressed size
+    centralHeader.writeUInt32LE(uncompressedBuf.length, 24); // uncompressed size
+    centralHeader.writeUInt16LE(fileNameBuf.length, 28); // file name length
+    centralHeader.writeUInt16LE(0, 30); // extra field length
+    centralHeader.writeUInt16LE(0, 32); // file comment length
+    centralHeader.writeUInt16LE(0, 34); // disk number start
+    centralHeader.writeUInt16LE(0, 36); // internal file attributes
+    centralHeader.writeUInt32LE(0, 38); // external file attributes
+    centralHeader.writeUInt32LE(entry.localHeaderOffset, 42); // local header offset
+
+    centralEntries.push(Buffer.concat([centralHeader, fileNameBuf]));
+    centralDirSize += 46 + fileNameBuf.length;
+  }
+
+  const centralDirBuf = Buffer.concat(centralEntries);
+  const centralDirOffset = entries.length > 0
+    ? entries[entries.length - 1].localHeaderOffset +
+      30 +
+      Buffer.from(entries[entries.length - 1].fileName).length +
+      deflateRawSync(Buffer.from(entries[entries.length - 1].content)).length +
+      (16) // data descriptor size
+    : 0;
+
+  // End of central directory record
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0); // EOCD signature
+  eocd.writeUInt16LE(0, 4); // disk number
+  eocd.writeUInt16LE(0, 6); // disk with central dir
+  eocd.writeUInt16LE(entries.length, 8); // entries on this disk
+  eocd.writeUInt16LE(entries.length, 10); // total entries
+  eocd.writeUInt32LE(centralDirSize, 12); // central dir size
+  eocd.writeUInt32LE(centralDirOffset, 16); // central dir offset
+  eocd.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([centralDirBuf, eocd]);
+}
+
+/**
+ * Build a complete ZIP with data descriptor entries + central directory
+ */
+function buildZipWithDataDescriptors(
+  files: Array<{ fileName: string; content: string }>
+): Buffer {
+  const localEntries: Buffer[] = [];
+  const entryMeta: Array<{ fileName: string; content: string; localHeaderOffset: number }> = [];
+  let offset = 0;
+
+  for (const file of files) {
+    entryMeta.push({ ...file, localHeaderOffset: offset });
+    const entry = buildZipEntry(file.fileName, file.content, { useDataDescriptor: true });
+    localEntries.push(entry);
+    offset += entry.length;
+  }
+
+  const localData = Buffer.concat(localEntries);
+  const centralDir = buildZipCentralDirectory(entryMeta);
+
+  return Buffer.concat([localData, centralDir]);
+}
+
+describe("extractCsvFilesFromZip", () => {
+  it("extracts all CSV files from a ZIP without data descriptors", async () => {
+    const files = [
+      { fileName: "cgm_data_1.csv", content: "Timestamp,Value\n2024-01-01,100\n" },
+      { fileName: "bolus_data_1.csv", content: "Timestamp,Insulin\n2024-01-01,5.0\n" },
+      { fileName: "insulin_data_1.csv", content: "Timestamp,Total\n2024-01-01,42.0\n" },
+    ];
+
+    // Build ZIP without data descriptors (standard)
+    const localEntries = files.map((f) =>
+      buildZipEntry(f.fileName, f.content, { useDataDescriptor: false })
+    );
+    const localData = Buffer.concat(localEntries);
+    // No central directory needed for standard ZIPs (existing parser works)
+    const zip = localData;
+
+    const result = await extractCsvFilesFromZip(zip);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((f) => f.fileName)).toEqual([
+      "cgm_data_1.csv",
+      "bolus_data_1.csv",
+      "insulin_data_1.csv",
+    ]);
+    expect(result[0].content).toContain("Timestamp,Value");
+    expect(result[1].content).toContain("Timestamp,Insulin");
+    expect(result[2].content).toContain("Timestamp,Total");
+  });
+
+  it("extracts all CSV files from a ZIP with data descriptors (bit 3 flag)", async () => {
+    const files = [
+      { fileName: "cgm_data_1.csv", content: "Timestamp,Value\n2024-01-01,100\n" },
+      { fileName: "bolus_data_1.csv", content: "Timestamp,Insulin\n2024-01-01,5.0\n" },
+      { fileName: "insulin_data_1.csv", content: "Timestamp,Total\n2024-01-01,42.0\n" },
+    ];
+
+    const zip = buildZipWithDataDescriptors(files);
+    const result = await extractCsvFilesFromZip(zip);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((f) => f.fileName)).toEqual([
+      "cgm_data_1.csv",
+      "bolus_data_1.csv",
+      "insulin_data_1.csv",
+    ]);
+    expect(result[0].content).toContain("Timestamp,Value");
+    expect(result[1].content).toContain("Timestamp,Insulin");
+    expect(result[2].content).toContain("Timestamp,Total");
+  });
+
+  it("skips non-CSV files in ZIP", async () => {
+    const files = [
+      { fileName: "readme.txt", content: "Not a CSV" },
+      { fileName: "cgm_data_1.csv", content: "Timestamp,Value\n2024-01-01,100\n" },
+    ];
+
+    const zip = buildZipWithDataDescriptors(files);
+    const result = await extractCsvFilesFromZip(zip);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].fileName).toBe("cgm_data_1.csv");
   });
 });

--- a/packages/functions/src/glooko/scraper.test.ts
+++ b/packages/functions/src/glooko/scraper.test.ts
@@ -198,86 +198,83 @@ function buildZipEntry(
 }
 
 /**
- * Helper to build a ZIP central directory + EOCD for given entries
- */
-function buildZipCentralDirectory(
-  entries: Array<{ fileName: string; content: string; localHeaderOffset: number }>
-): Buffer {
-  const centralEntries: Buffer[] = [];
-  let centralDirSize = 0;
-
-  for (const entry of entries) {
-    const fileNameBuf = Buffer.from(entry.fileName, "utf-8");
-    const uncompressedBuf = Buffer.from(entry.content, "utf-8");
-    const compressedBuf = deflateRawSync(uncompressedBuf);
-
-    const centralHeader = Buffer.alloc(46);
-    centralHeader.writeUInt32LE(0x02014b50, 0); // central directory signature
-    centralHeader.writeUInt16LE(20, 4); // version made by
-    centralHeader.writeUInt16LE(20, 6); // version needed
-    centralHeader.writeUInt16LE(0, 8); // flags
-    centralHeader.writeUInt16LE(8, 10); // compression method
-    centralHeader.writeUInt16LE(0, 12); // mod time
-    centralHeader.writeUInt16LE(0, 14); // mod date
-    centralHeader.writeUInt32LE(0, 16); // crc32
-    centralHeader.writeUInt32LE(compressedBuf.length, 20); // compressed size
-    centralHeader.writeUInt32LE(uncompressedBuf.length, 24); // uncompressed size
-    centralHeader.writeUInt16LE(fileNameBuf.length, 28); // file name length
-    centralHeader.writeUInt16LE(0, 30); // extra field length
-    centralHeader.writeUInt16LE(0, 32); // file comment length
-    centralHeader.writeUInt16LE(0, 34); // disk number start
-    centralHeader.writeUInt16LE(0, 36); // internal file attributes
-    centralHeader.writeUInt32LE(0, 38); // external file attributes
-    centralHeader.writeUInt32LE(entry.localHeaderOffset, 42); // local header offset
-
-    centralEntries.push(Buffer.concat([centralHeader, fileNameBuf]));
-    centralDirSize += 46 + fileNameBuf.length;
-  }
-
-  const centralDirBuf = Buffer.concat(centralEntries);
-  const centralDirOffset = entries.length > 0
-    ? entries[entries.length - 1].localHeaderOffset +
-      30 +
-      Buffer.from(entries[entries.length - 1].fileName).length +
-      deflateRawSync(Buffer.from(entries[entries.length - 1].content)).length +
-      (16) // data descriptor size
-    : 0;
-
-  // End of central directory record
-  const eocd = Buffer.alloc(22);
-  eocd.writeUInt32LE(0x06054b50, 0); // EOCD signature
-  eocd.writeUInt16LE(0, 4); // disk number
-  eocd.writeUInt16LE(0, 6); // disk with central dir
-  eocd.writeUInt16LE(entries.length, 8); // entries on this disk
-  eocd.writeUInt16LE(entries.length, 10); // total entries
-  eocd.writeUInt32LE(centralDirSize, 12); // central dir size
-  eocd.writeUInt32LE(centralDirOffset, 16); // central dir offset
-  eocd.writeUInt16LE(0, 20); // comment length
-
-  return Buffer.concat([centralDirBuf, eocd]);
-}
-
-/**
- * Build a complete ZIP with data descriptor entries + central directory
+ * Build a complete ZIP with data descriptor entries + central directory.
+ * Tracks actual entry sizes to compute central directory offset deterministically.
  */
 function buildZipWithDataDescriptors(
   files: Array<{ fileName: string; content: string }>
 ): Buffer {
   const localEntries: Buffer[] = [];
-  const entryMeta: Array<{ fileName: string; content: string; localHeaderOffset: number }> = [];
+  const entryMeta: Array<{
+    fileName: string;
+    compressedSize: number;
+    uncompressedSize: number;
+    localHeaderOffset: number;
+    useDataDescriptor: boolean;
+  }> = [];
   let offset = 0;
 
   for (const file of files) {
-    entryMeta.push({ ...file, localHeaderOffset: offset });
+    const uncompressedBuf = Buffer.from(file.content, "utf-8");
+    const compressedBuf = deflateRawSync(uncompressedBuf);
+
+    entryMeta.push({
+      fileName: file.fileName,
+      compressedSize: compressedBuf.length,
+      uncompressedSize: uncompressedBuf.length,
+      localHeaderOffset: offset,
+      useDataDescriptor: true,
+    });
+
     const entry = buildZipEntry(file.fileName, file.content, { useDataDescriptor: true });
     localEntries.push(entry);
     offset += entry.length;
   }
 
   const localData = Buffer.concat(localEntries);
-  const centralDir = buildZipCentralDirectory(entryMeta);
+  const centralDirOffset = localData.length;
 
-  return Buffer.concat([localData, centralDir]);
+  // Build central directory entries
+  const centralEntries: Buffer[] = [];
+  for (const entry of entryMeta) {
+    const fileNameBuf = Buffer.from(entry.fileName, "utf-8");
+    const flags = entry.useDataDescriptor ? 0x0008 : 0x0000;
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(flags, 8);
+    centralHeader.writeUInt16LE(8, 10);
+    centralHeader.writeUInt16LE(0, 12);
+    centralHeader.writeUInt16LE(0, 14);
+    centralHeader.writeUInt32LE(0, 16); // crc32
+    centralHeader.writeUInt32LE(entry.compressedSize, 20);
+    centralHeader.writeUInt32LE(entry.uncompressedSize, 24);
+    centralHeader.writeUInt16LE(fileNameBuf.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(entry.localHeaderOffset, 42);
+    centralEntries.push(Buffer.concat([centralHeader, fileNameBuf]));
+  }
+
+  const centralDirBuf = Buffer.concat(centralEntries);
+
+  // End of central directory record
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entryMeta.length, 8);
+  eocd.writeUInt16LE(entryMeta.length, 10);
+  eocd.writeUInt32LE(centralDirBuf.length, 12);
+  eocd.writeUInt32LE(centralDirOffset, 16);
+  eocd.writeUInt16LE(0, 20);
+
+  return Buffer.concat([localData, centralDirBuf, eocd]);
 }
 
 describe("extractCsvFilesFromZip", () => {

--- a/packages/functions/src/glooko/scraper.ts
+++ b/packages/functions/src/glooko/scraper.ts
@@ -48,51 +48,131 @@ const NAVIGATION_TIMEOUT = 30000;
 // ExtractedCsv is imported from types.ts
 
 /**
- * Extract CSV files from a ZIP file buffer
- * Glooko exports data as a ZIP containing multiple CSV files
+ * Parse the central directory to get accurate file metadata.
+ * The central directory (at end of ZIP) always has correct sizes,
+ * unlike local file headers which may use data descriptors (0xFFFFFFFF).
  */
-async function extractCsvFilesFromZip(buffer: Buffer): Promise<ExtractedCsv[]> {
+function parseCentralDirectory(buffer: Buffer): Array<{
+  fileName: string;
+  compressedSize: number;
+  uncompressedSize: number;
+  compressionMethod: number;
+  localHeaderOffset: number;
+}> {
+  // Find End of Central Directory record (EOCD) by scanning backwards
+  // EOCD signature: 0x06054b50
+  let eocdOffset = -1;
+  for (let i = buffer.length - 22; i >= 0; i--) {
+    if (buffer.readUInt32LE(i) === 0x06054b50) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  if (eocdOffset === -1) return [];
+
+  const entryCount = buffer.readUInt16LE(eocdOffset + 10);
+  const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
+
+  const entries: Array<{
+    fileName: string;
+    compressedSize: number;
+    uncompressedSize: number;
+    compressionMethod: number;
+    localHeaderOffset: number;
+  }> = [];
+
+  let offset = centralDirOffset;
+  for (let i = 0; i < entryCount && offset < eocdOffset; i++) {
+    if (buffer.readUInt32LE(offset) !== 0x02014b50) break;
+
+    const compressionMethod = buffer.readUInt16LE(offset + 10);
+    const compressedSize = buffer.readUInt32LE(offset + 20);
+    const uncompressedSize = buffer.readUInt32LE(offset + 24);
+    const fileNameLength = buffer.readUInt16LE(offset + 28);
+    const extraFieldLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+    const fileName = buffer.toString("utf-8", offset + 46, offset + 46 + fileNameLength);
+
+    entries.push({ fileName, compressedSize, uncompressedSize, compressionMethod, localHeaderOffset });
+    offset += 46 + fileNameLength + extraFieldLength + commentLength;
+  }
+
+  return entries;
+}
+
+/**
+ * Extract CSV files from a ZIP file buffer.
+ * Uses the central directory for accurate sizes, handling ZIPs that use
+ * data descriptors (bit 3 of general purpose flags) where local file
+ * headers have 0xFFFFFFFF for sizes.
+ */
+export async function extractCsvFilesFromZip(buffer: Buffer): Promise<ExtractedCsv[]> {
   const { inflateRawSync } = await import("zlib");
-
-  // ZIP file format:
-  // Local file header starts with 0x04034b50 (PK\003\004)
-  // We need to find the CSV files and extract them
-
-  let offset = 0;
   const csvFiles: ExtractedCsv[] = [];
 
-  while (offset < buffer.length - 30) {
-    // Check for local file header signature
-    const signature = buffer.readUInt32LE(offset);
-    if (signature !== 0x04034b50) {
-      break; // No more files
+  // Try central directory first (handles data descriptors correctly)
+  const centralEntries = parseCentralDirectory(buffer);
+
+  if (centralEntries.length > 0) {
+    for (const entry of centralEntries) {
+      console.log(`ZIP entry: ${entry.fileName} (compressed: ${entry.compressedSize}, uncompressed: ${entry.uncompressedSize}, method: ${entry.compressionMethod})`);
+
+      if (!entry.fileName.toLowerCase().endsWith(".csv")) continue;
+
+      // Read local file header to find data offset (skip variable-length fields)
+      const localFileNameLength = buffer.readUInt16LE(entry.localHeaderOffset + 26);
+      const localExtraFieldLength = buffer.readUInt16LE(entry.localHeaderOffset + 28);
+      const dataOffset = entry.localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength;
+
+      const compressedData = buffer.slice(dataOffset, dataOffset + entry.compressedSize);
+
+      let csvContent: string;
+      if (entry.compressionMethod === 0) {
+        csvContent = compressedData.toString("utf-8");
+      } else if (entry.compressionMethod === 8) {
+        try {
+          const decompressed = inflateRawSync(compressedData);
+          csvContent = decompressed.toString("utf-8");
+        } catch (err) {
+          console.error(`Failed to decompress ${entry.fileName}: ${err}`);
+          continue;
+        }
+      } else {
+        console.warn(`Unknown compression method ${entry.compressionMethod} for ${entry.fileName}`);
+        continue;
+      }
+
+      console.log(`Extracted ${entry.fileName}: ${csvContent.length} bytes`);
+      csvFiles.push({ fileName: entry.fileName, content: csvContent });
     }
 
-    // Parse local file header
+    return csvFiles;
+  }
+
+  // Fallback: parse local file headers (works for ZIPs without data descriptors)
+  let offset = 0;
+  while (offset < buffer.length - 30) {
+    const signature = buffer.readUInt32LE(offset);
+    if (signature !== 0x04034b50) break;
+
     const compressionMethod = buffer.readUInt16LE(offset + 8);
     const compressedSize = buffer.readUInt32LE(offset + 18);
-    const uncompressedSize = buffer.readUInt32LE(offset + 22);
     const fileNameLength = buffer.readUInt16LE(offset + 26);
     const extraFieldLength = buffer.readUInt16LE(offset + 28);
-
-    // Get filename
     const fileName = buffer.toString("utf-8", offset + 30, offset + 30 + fileNameLength);
-
-    // Calculate data offset
     const dataOffset = offset + 30 + fileNameLength + extraFieldLength;
 
-    console.log(`ZIP entry: ${fileName} (compressed: ${compressedSize}, uncompressed: ${uncompressedSize}, method: ${compressionMethod})`);
+    console.log(`ZIP entry (fallback): ${fileName} (compressed: ${compressedSize}, method: ${compressionMethod})`);
 
-    // Check if this is a CSV file
     if (fileName.toLowerCase().endsWith(".csv")) {
       const compressedData = buffer.slice(dataOffset, dataOffset + compressedSize);
 
       let csvContent: string;
       if (compressionMethod === 0) {
-        // Stored (no compression)
         csvContent = compressedData.toString("utf-8");
       } else if (compressionMethod === 8) {
-        // Deflate
         try {
           const decompressed = inflateRawSync(compressedData);
           csvContent = decompressed.toString("utf-8");
@@ -111,7 +191,6 @@ async function extractCsvFilesFromZip(buffer: Buffer): Promise<ExtractedCsv[]> {
       csvFiles.push({ fileName, content: csvContent });
     }
 
-    // Move to next file
     offset = dataOffset + compressedSize;
   }
 

--- a/packages/functions/src/glooko/scraper.ts
+++ b/packages/functions/src/glooko/scraper.ts
@@ -48,9 +48,12 @@ const NAVIGATION_TIMEOUT = 30000;
 // ExtractedCsv is imported from types.ts
 
 /**
- * Parse the central directory to get accurate file metadata.
- * The central directory (at end of ZIP) always has correct sizes,
- * unlike local file headers which may use data descriptors (0xFFFFFFFF).
+ * Parse the central directory to get file metadata using the standard ZIP fields.
+ * This relies on the 32-bit size values stored in the central directory and does
+ * not interpret ZIP64 extra fields, so ZIP64 archives that store 0xFFFFFFFF here
+ * are not fully supported.
+ *
+ * Returns an empty array if the central directory cannot be found or parsed.
  */
 function parseCentralDirectory(buffer: Buffer): Array<{
   fileName: string;
@@ -59,47 +62,56 @@ function parseCentralDirectory(buffer: Buffer): Array<{
   compressionMethod: number;
   localHeaderOffset: number;
 }> {
-  // Find End of Central Directory record (EOCD) by scanning backwards
-  // EOCD signature: 0x06054b50
-  let eocdOffset = -1;
-  for (let i = buffer.length - 22; i >= 0; i--) {
-    if (buffer.readUInt32LE(i) === 0x06054b50) {
-      eocdOffset = i;
-      break;
+  try {
+    // Find End of Central Directory record (EOCD) by scanning backwards
+    // EOCD signature: 0x06054b50
+    let eocdOffset = -1;
+    for (let i = buffer.length - 22; i >= 0; i--) {
+      if (buffer.readUInt32LE(i) === 0x06054b50) {
+        eocdOffset = i;
+        break;
+      }
     }
+
+    if (eocdOffset === -1) return [];
+
+    const entryCount = buffer.readUInt16LE(eocdOffset + 10);
+    const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
+
+    if (centralDirOffset >= eocdOffset) return [];
+
+    const entries: Array<{
+      fileName: string;
+      compressedSize: number;
+      uncompressedSize: number;
+      compressionMethod: number;
+      localHeaderOffset: number;
+    }> = [];
+
+    let offset = centralDirOffset;
+    for (let i = 0; i < entryCount && offset + 46 <= eocdOffset; i++) {
+      if (buffer.readUInt32LE(offset) !== 0x02014b50) break;
+
+      const compressionMethod = buffer.readUInt16LE(offset + 10);
+      const compressedSize = buffer.readUInt32LE(offset + 20);
+      const uncompressedSize = buffer.readUInt32LE(offset + 24);
+      const fileNameLength = buffer.readUInt16LE(offset + 28);
+      const extraFieldLength = buffer.readUInt16LE(offset + 30);
+      const commentLength = buffer.readUInt16LE(offset + 32);
+      const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+
+      if (offset + 46 + fileNameLength > buffer.length) break;
+      const fileName = buffer.toString("utf-8", offset + 46, offset + 46 + fileNameLength);
+
+      entries.push({ fileName, compressedSize, uncompressedSize, compressionMethod, localHeaderOffset });
+      offset += 46 + fileNameLength + extraFieldLength + commentLength;
+    }
+
+    return entries;
+  } catch {
+    // Malformed/truncated ZIP — fall back to local file header parsing
+    return [];
   }
-
-  if (eocdOffset === -1) return [];
-
-  const entryCount = buffer.readUInt16LE(eocdOffset + 10);
-  const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
-
-  const entries: Array<{
-    fileName: string;
-    compressedSize: number;
-    uncompressedSize: number;
-    compressionMethod: number;
-    localHeaderOffset: number;
-  }> = [];
-
-  let offset = centralDirOffset;
-  for (let i = 0; i < entryCount && offset < eocdOffset; i++) {
-    if (buffer.readUInt32LE(offset) !== 0x02014b50) break;
-
-    const compressionMethod = buffer.readUInt16LE(offset + 10);
-    const compressedSize = buffer.readUInt32LE(offset + 20);
-    const uncompressedSize = buffer.readUInt32LE(offset + 24);
-    const fileNameLength = buffer.readUInt16LE(offset + 28);
-    const extraFieldLength = buffer.readUInt16LE(offset + 30);
-    const commentLength = buffer.readUInt16LE(offset + 32);
-    const localHeaderOffset = buffer.readUInt32LE(offset + 42);
-    const fileName = buffer.toString("utf-8", offset + 46, offset + 46 + fileNameLength);
-
-    entries.push({ fileName, compressedSize, uncompressedSize, compressionMethod, localHeaderOffset });
-    offset += 46 + fileNameLength + extraFieldLength + commentLength;
-  }
-
-  return entries;
 }
 
 /**
@@ -121,10 +133,25 @@ export async function extractCsvFilesFromZip(buffer: Buffer): Promise<ExtractedC
 
       if (!entry.fileName.toLowerCase().endsWith(".csv")) continue;
 
+      // Validate local header before reading variable-length fields
+      if (entry.localHeaderOffset + 30 > buffer.length) {
+        console.warn(`Skipping ${entry.fileName}: local header offset out of bounds`);
+        continue;
+      }
+      if (buffer.readUInt32LE(entry.localHeaderOffset) !== 0x04034b50) {
+        console.warn(`Skipping ${entry.fileName}: invalid local header signature`);
+        continue;
+      }
+
       // Read local file header to find data offset (skip variable-length fields)
       const localFileNameLength = buffer.readUInt16LE(entry.localHeaderOffset + 26);
       const localExtraFieldLength = buffer.readUInt16LE(entry.localHeaderOffset + 28);
       const dataOffset = entry.localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength;
+
+      if (dataOffset + entry.compressedSize > buffer.length) {
+        console.warn(`Skipping ${entry.fileName}: data extends beyond buffer`);
+        continue;
+      }
 
       const compressedData = buffer.slice(dataOffset, dataOffset + entry.compressedSize);
 


### PR DESCRIPTION
## Summary
- Glooko's ZIP exports use data descriptors (bit 3 flag), which set local file header sizes to `0xFFFFFFFF`
- The ZIP parser used these bogus sizes to advance through the archive, so only the first CSV file was extracted
- This meant only CGM data was imported — no bolus, insulin, basal, or treatment data — causing daily insulin totals to show 0 for 4+ days
- Fixed by parsing the central directory (always has accurate sizes) instead of relying on local file headers

## Test plan
- [x] Added test for ZIP with data descriptors containing multiple CSV files
- [x] Added test for ZIP without data descriptors (regression)
- [x] Added test for skipping non-CSV files
- [x] All 14 scraper tests pass
- [x] Full test suite passes (265 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)