### PR TITLE
Fix ZIP extraction: handle 0xFFFFFFFF in central directory

### DIFF
--- a/changes/2026-03-07-0857-fix-zip-sentinel-sizes.md
+++ b/changes/2026-03-07-0857-fix-zip-sentinel-sizes.md
@@ -1,0 +1,18 @@
+# Fix ZIP extraction when central directory also has 0xFFFFFFFF sizes
+
+*Date: 2026-03-07 0857*
+
+## Why
+PR #249 fixed ZIP extraction to use the central directory for file sizes instead of unreliable local file headers. However, Glooko's ZIP exports store 0xFFFFFFFF in BOTH locations — the central directory sizes are sentinel values too. The bounds check correctly rejected these as invalid, causing ALL files to be skipped (worse than before: 0 files instead of 1).
+
+## How
+When central directory sizes are 0xFFFFFFFF, we compute data regions from consecutive local header offsets (which the central directory stores correctly). The compressed data for entry N sits between its local header's data start and the next entry's local header. `inflateRawSync` naturally stops at the deflate stream boundary within this region, correctly handling any trailing data descriptors.
+
+## Key Design Decisions
+- Sort entries by local header offset to compute boundaries between consecutive entries
+- Use the central directory's own start offset as the boundary for the last entry
+- Let `inflateRawSync` find the deflate stream end rather than computing exact sizes
+- Added test that reproduces Glooko's exact ZIP format (0xFFFFFFFF everywhere)
+
+## What's Next
+- Monitor next scraper run to confirm all 12 CSV file types are extracted

--- a/packages/functions/src/glooko/scraper.test.ts
+++ b/packages/functions/src/glooko/scraper.test.ts
@@ -157,15 +157,15 @@ invalid-date,5.0,
 function buildZipEntry(
   fileName: string,
   content: string,
-  options: { useDataDescriptor?: boolean } = {}
+  options: { useDataDescriptor?: boolean; stored?: boolean } = {}
 ): Buffer {
-  const { useDataDescriptor = false } = options;
+  const { useDataDescriptor = false, stored = false } = options;
   const fileNameBuf = Buffer.from(fileName, "utf-8");
   const uncompressedBuf = Buffer.from(content, "utf-8");
-  const compressedBuf = deflateRawSync(uncompressedBuf);
+  const dataBuf = stored ? uncompressedBuf : deflateRawSync(uncompressedBuf);
 
   const generalPurposeFlags = useDataDescriptor ? 0x0008 : 0x0000;
-  const headerCompressedSize = useDataDescriptor ? 0xffffffff : compressedBuf.length;
+  const headerDataSize = useDataDescriptor ? 0xffffffff : dataBuf.length;
   const headerUncompressedSize = useDataDescriptor ? 0xffffffff : uncompressedBuf.length;
 
   // Local file header (30 bytes + fileName)
@@ -173,23 +173,23 @@ function buildZipEntry(
   header.writeUInt32LE(0x04034b50, 0); // signature
   header.writeUInt16LE(20, 4); // version needed
   header.writeUInt16LE(generalPurposeFlags, 6);
-  header.writeUInt16LE(8, 8); // compression method: deflate
+  header.writeUInt16LE(stored ? 0 : 8, 8); // compression method
   header.writeUInt16LE(0, 10); // mod time
   header.writeUInt16LE(0, 12); // mod date
   header.writeUInt32LE(0, 14); // crc32 (placeholder)
-  header.writeUInt32LE(headerCompressedSize, 18);
+  header.writeUInt32LE(headerDataSize, 18);
   header.writeUInt32LE(headerUncompressedSize, 22);
   header.writeUInt16LE(fileNameBuf.length, 26);
   header.writeUInt16LE(0, 28); // extra field length
 
-  const parts = [header, fileNameBuf, compressedBuf];
+  const parts: Buffer[] = [header, fileNameBuf, dataBuf];
 
   if (useDataDescriptor) {
     // Data descriptor: signature + crc32 + compressed size + uncompressed size
     const descriptor = Buffer.alloc(16);
     descriptor.writeUInt32LE(0x08074b50, 0); // data descriptor signature
     descriptor.writeUInt32LE(0, 4); // crc32 (placeholder)
-    descriptor.writeUInt32LE(compressedBuf.length, 8);
+    descriptor.writeUInt32LE(dataBuf.length, 8);
     descriptor.writeUInt32LE(uncompressedBuf.length, 12);
     parts.push(descriptor);
   }
@@ -203,7 +203,7 @@ function buildZipEntry(
  * for sizes (matching Glooko's actual ZIP output).
  */
 function buildZipWithDataDescriptors(
-  files: Array<{ fileName: string; content: string }>,
+  files: Array<{ fileName: string; content: string; stored?: boolean }>,
   options: { sentinelSizes?: boolean } = {}
 ): Buffer {
   const { sentinelSizes = false } = options;
@@ -212,22 +212,27 @@ function buildZipWithDataDescriptors(
     fileName: string;
     compressedSize: number;
     uncompressedSize: number;
+    compressionMethod: number;
     localHeaderOffset: number;
   }> = [];
   let offset = 0;
 
   for (const file of files) {
     const uncompressedBuf = Buffer.from(file.content, "utf-8");
-    const compressedBuf = deflateRawSync(uncompressedBuf);
+    const dataBuf = file.stored ? uncompressedBuf : deflateRawSync(uncompressedBuf);
 
     entryMeta.push({
       fileName: file.fileName,
-      compressedSize: compressedBuf.length,
+      compressedSize: dataBuf.length,
       uncompressedSize: uncompressedBuf.length,
+      compressionMethod: file.stored ? 0 : 8,
       localHeaderOffset: offset,
     });
 
-    const entry = buildZipEntry(file.fileName, file.content, { useDataDescriptor: true });
+    const entry = buildZipEntry(file.fileName, file.content, {
+      useDataDescriptor: true,
+      stored: file.stored,
+    });
     localEntries.push(entry);
     offset += entry.length;
   }
@@ -245,7 +250,7 @@ function buildZipWithDataDescriptors(
     centralHeader.writeUInt16LE(20, 4);
     centralHeader.writeUInt16LE(20, 6);
     centralHeader.writeUInt16LE(0x0008, 8); // data descriptor flag
-    centralHeader.writeUInt16LE(8, 10);
+    centralHeader.writeUInt16LE(entry.compressionMethod, 10);
     centralHeader.writeUInt16LE(0, 12);
     centralHeader.writeUInt16LE(0, 14);
     centralHeader.writeUInt32LE(0, 16); // crc32
@@ -346,6 +351,21 @@ describe("extractCsvFilesFromZip", () => {
     expect(result[0].content).toContain("Timestamp,Value");
     expect(result[1].content).toContain("Timestamp,Insulin");
     expect(result[2].content).toContain("Timestamp,Total");
+  });
+
+  it("handles stored (uncompressed) entries with sentinel sizes without descriptor corruption", async () => {
+    const files = [
+      { fileName: "cgm_data_1.csv", content: "Timestamp,Value\n2024-01-01,100\n", stored: true },
+      { fileName: "bolus_data_1.csv", content: "Timestamp,Insulin\n2024-01-01,5.0\n", stored: true },
+    ];
+
+    const zip = buildZipWithDataDescriptors(files, { sentinelSizes: true });
+    const result = await extractCsvFilesFromZip(zip);
+
+    expect(result).toHaveLength(2);
+    // Content must NOT contain data descriptor bytes
+    expect(result[0].content).toBe("Timestamp,Value\n2024-01-01,100\n");
+    expect(result[1].content).toBe("Timestamp,Insulin\n2024-01-01,5.0\n");
   });
 
   it("skips non-CSV files in ZIP", async () => {

--- a/packages/functions/src/glooko/scraper.test.ts
+++ b/packages/functions/src/glooko/scraper.test.ts
@@ -199,18 +199,20 @@ function buildZipEntry(
 
 /**
  * Build a complete ZIP with data descriptor entries + central directory.
- * Tracks actual entry sizes to compute central directory offset deterministically.
+ * When sentinelSizes is true, the central directory also stores 0xFFFFFFFF
+ * for sizes (matching Glooko's actual ZIP output).
  */
 function buildZipWithDataDescriptors(
-  files: Array<{ fileName: string; content: string }>
+  files: Array<{ fileName: string; content: string }>,
+  options: { sentinelSizes?: boolean } = {}
 ): Buffer {
+  const { sentinelSizes = false } = options;
   const localEntries: Buffer[] = [];
   const entryMeta: Array<{
     fileName: string;
     compressedSize: number;
     uncompressedSize: number;
     localHeaderOffset: number;
-    useDataDescriptor: boolean;
   }> = [];
   let offset = 0;
 
@@ -223,7 +225,6 @@ function buildZipWithDataDescriptors(
       compressedSize: compressedBuf.length,
       uncompressedSize: uncompressedBuf.length,
       localHeaderOffset: offset,
-      useDataDescriptor: true,
     });
 
     const entry = buildZipEntry(file.fileName, file.content, { useDataDescriptor: true });
@@ -238,19 +239,18 @@ function buildZipWithDataDescriptors(
   const centralEntries: Buffer[] = [];
   for (const entry of entryMeta) {
     const fileNameBuf = Buffer.from(entry.fileName, "utf-8");
-    const flags = entry.useDataDescriptor ? 0x0008 : 0x0000;
 
     const centralHeader = Buffer.alloc(46);
     centralHeader.writeUInt32LE(0x02014b50, 0);
     centralHeader.writeUInt16LE(20, 4);
     centralHeader.writeUInt16LE(20, 6);
-    centralHeader.writeUInt16LE(flags, 8);
+    centralHeader.writeUInt16LE(0x0008, 8); // data descriptor flag
     centralHeader.writeUInt16LE(8, 10);
     centralHeader.writeUInt16LE(0, 12);
     centralHeader.writeUInt16LE(0, 14);
     centralHeader.writeUInt32LE(0, 16); // crc32
-    centralHeader.writeUInt32LE(entry.compressedSize, 20);
-    centralHeader.writeUInt32LE(entry.uncompressedSize, 24);
+    centralHeader.writeUInt32LE(sentinelSizes ? 0xffffffff : entry.compressedSize, 20);
+    centralHeader.writeUInt32LE(sentinelSizes ? 0xffffffff : entry.uncompressedSize, 24);
     centralHeader.writeUInt16LE(fileNameBuf.length, 28);
     centralHeader.writeUInt16LE(0, 30);
     centralHeader.writeUInt16LE(0, 32);
@@ -314,6 +314,27 @@ describe("extractCsvFilesFromZip", () => {
     ];
 
     const zip = buildZipWithDataDescriptors(files);
+    const result = await extractCsvFilesFromZip(zip);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((f) => f.fileName)).toEqual([
+      "cgm_data_1.csv",
+      "bolus_data_1.csv",
+      "insulin_data_1.csv",
+    ]);
+    expect(result[0].content).toContain("Timestamp,Value");
+    expect(result[1].content).toContain("Timestamp,Insulin");
+    expect(result[2].content).toContain("Timestamp,Total");
+  });
+
+  it("extracts files when central directory also has 0xFFFFFFFF sizes (Glooko format)", async () => {
+    const files = [
+      { fileName: "cgm_data_1.csv", content: "Timestamp,Value\n2024-01-01,100\n" },
+      { fileName: "bolus_data_1.csv", content: "Timestamp,Insulin\n2024-01-01,5.0\n" },
+      { fileName: "insulin_data_1.csv", content: "Timestamp,Total\n2024-01-01,42.0\n" },
+    ];
+
+    const zip = buildZipWithDataDescriptors(files, { sentinelSizes: true });
     const result = await extractCsvFilesFromZip(zip);
 
     expect(result).toHaveLength(3);

--- a/packages/functions/src/glooko/scraper.ts
+++ b/packages/functions/src/glooko/scraper.ts
@@ -115,25 +115,53 @@ function parseCentralDirectory(buffer: Buffer): Array<{
 }
 
 /**
+ * Find the EOCD record and return the central directory offset.
+ * Returns -1 if not found.
+ */
+function findCentralDirOffset(buffer: Buffer): number {
+  for (let i = buffer.length - 22; i >= 0; i--) {
+    if (buffer.readUInt32LE(i) === 0x06054b50) {
+      return buffer.readUInt32LE(i + 16);
+    }
+  }
+  return -1;
+}
+
+/**
+ * Compute the data start offset for a local file header at the given position.
+ */
+function localHeaderDataOffset(buffer: Buffer, headerOffset: number): number {
+  const fileNameLength = buffer.readUInt16LE(headerOffset + 26);
+  const extraFieldLength = buffer.readUInt16LE(headerOffset + 28);
+  return headerOffset + 30 + fileNameLength + extraFieldLength;
+}
+
+/**
  * Extract CSV files from a ZIP file buffer.
- * Uses the central directory for accurate sizes, handling ZIPs that use
- * data descriptors (bit 3 of general purpose flags) where local file
- * headers have 0xFFFFFFFF for sizes.
+ * Handles ZIPs where both local headers and central directory store 0xFFFFFFFF
+ * for sizes (data descriptor ZIPs). Uses central directory for file names and
+ * local header offsets, then computes data regions from consecutive offsets
+ * and lets inflateRawSync find the actual deflate stream boundary.
  */
 export async function extractCsvFilesFromZip(buffer: Buffer): Promise<ExtractedCsv[]> {
   const { inflateRawSync } = await import("zlib");
   const csvFiles: ExtractedCsv[] = [];
 
-  // Try central directory first (handles data descriptors correctly)
+  // Try central directory first (gives us file names and local header offsets)
   const centralEntries = parseCentralDirectory(buffer);
+  const centralDirOffset = findCentralDirOffset(buffer);
 
-  if (centralEntries.length > 0) {
-    for (const entry of centralEntries) {
+  if (centralEntries.length > 0 && centralDirOffset > 0) {
+    // Sort entries by local header offset to compute data boundaries
+    const sorted = [...centralEntries].sort((a, b) => a.localHeaderOffset - b.localHeaderOffset);
+
+    for (let idx = 0; idx < sorted.length; idx++) {
+      const entry = sorted[idx];
       console.log(`ZIP entry: ${entry.fileName} (compressed: ${entry.compressedSize}, uncompressed: ${entry.uncompressedSize}, method: ${entry.compressionMethod})`);
 
       if (!entry.fileName.toLowerCase().endsWith(".csv")) continue;
 
-      // Validate local header before reading variable-length fields
+      // Validate local header
       if (entry.localHeaderOffset + 30 > buffer.length) {
         console.warn(`Skipping ${entry.fileName}: local header offset out of bounds`);
         continue;
@@ -143,17 +171,27 @@ export async function extractCsvFilesFromZip(buffer: Buffer): Promise<ExtractedC
         continue;
       }
 
-      // Read local file header to find data offset (skip variable-length fields)
-      const localFileNameLength = buffer.readUInt16LE(entry.localHeaderOffset + 26);
-      const localExtraFieldLength = buffer.readUInt16LE(entry.localHeaderOffset + 28);
-      const dataOffset = entry.localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength;
+      const dataOffset = localHeaderDataOffset(buffer, entry.localHeaderOffset);
 
-      if (dataOffset + entry.compressedSize > buffer.length) {
-        console.warn(`Skipping ${entry.fileName}: data extends beyond buffer`);
+      // Determine compressed size: use central directory value if valid,
+      // otherwise compute from the gap between this entry's data and the
+      // next entry's local header (or the central directory)
+      let compressedSize = entry.compressedSize;
+      if (compressedSize === 0xffffffff || dataOffset + compressedSize > buffer.length) {
+        const nextBoundary = idx + 1 < sorted.length
+          ? sorted[idx + 1].localHeaderOffset
+          : centralDirOffset;
+        // The gap contains: compressed data + optional data descriptor (16 bytes)
+        // Give inflateRawSync the full region; it stops at the deflate stream end
+        compressedSize = nextBoundary - dataOffset;
+      }
+
+      if (dataOffset + compressedSize > buffer.length || compressedSize <= 0) {
+        console.warn(`Skipping ${entry.fileName}: computed data region out of bounds`);
         continue;
       }
 
-      const compressedData = buffer.slice(dataOffset, dataOffset + entry.compressedSize);
+      const compressedData = buffer.slice(dataOffset, dataOffset + compressedSize);
 
       let csvContent: string;
       if (entry.compressionMethod === 0) {

--- a/packages/functions/src/glooko/scraper.ts
+++ b/packages/functions/src/glooko/scraper.ts
@@ -177,13 +177,18 @@ export async function extractCsvFilesFromZip(buffer: Buffer): Promise<ExtractedC
       // otherwise compute from the gap between this entry's data and the
       // next entry's local header (or the central directory)
       let compressedSize = entry.compressedSize;
+      const hasDataDescriptor = (buffer.readUInt16LE(entry.localHeaderOffset + 6) & 0x0008) !== 0;
       if (compressedSize === 0xffffffff || dataOffset + compressedSize > buffer.length) {
         const nextBoundary = idx + 1 < sorted.length
           ? sorted[idx + 1].localHeaderOffset
           : centralDirOffset;
-        // The gap contains: compressed data + optional data descriptor (16 bytes)
-        // Give inflateRawSync the full region; it stops at the deflate stream end
-        compressedSize = nextBoundary - dataOffset;
+        const regionSize = nextBoundary - dataOffset;
+        // For deflate (method 8), inflateRawSync stops at stream end so extra
+        // trailing bytes (data descriptor) are harmless. For stored (method 0),
+        // we must subtract the 16-byte data descriptor to avoid corrupting content.
+        compressedSize = hasDataDescriptor && entry.compressionMethod === 0
+          ? regionSize - 16
+          : regionSize;
       }
 
       if (dataOffset + compressedSize > buffer.length || compressedSize <= 0) {


### PR DESCRIPTION
## Summary
- **Hotfix for #249** which made things worse: Glooko's ZIPs store `0xFFFFFFFF` in the central directory too, not just local headers
- The bounds check from #249 correctly rejected these, causing **all** files to be skipped (0 instead of 1)
- Now computes data regions from consecutive local header offsets when sizes are `0xFFFFFFFF`
- `inflateRawSync` finds the actual deflate stream end within each region

## Test plan
- [x] Added test reproducing Glooko's exact ZIP format (sentinel sizes everywhere)
- [x] Existing tests still pass (data descriptors, standard ZIPs, non-CSV filtering)
- [x] All 15 scraper tests pass
- [x] Full test suite passes (415 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)