### PR TITLE
feat(relay): heartbeat Pixoo health to glucagent DynamoDB

### DIFF
--- a/changes/2026-05-14-0507-relay-pixoo-health-heartbeat.md
+++ b/changes/2026-05-14-0507-relay-pixoo-health-heartbeat.md
@@ -1,0 +1,41 @@
+# Relay: Pixoo Health Heartbeat to Glucagent
+
+*Date: 2026-05-14 0507 UTC*
+
+## Why
+
+When the Pixoo's HTTP daemon hangs (a known Divoom firmware quirk — device pings but port 80 dies), the display goes dark and the only signal is `journalctl` on the Lightsail relay. The cloud side (`glucagent#130` / `glucagent#131`) builds the monitoring + email path; this change is the relay-side half — it writes per-frame health heartbeats into glucagent's DynamoDB so the monitor has something to read.
+
+Diagnosed manually on 2026-05-13 when the Pixoo hung at 00:14 PT (~6 minutes of failed frames before I noticed the dark display).
+
+## How
+
+1. **New module: `packages/relay/src/heartbeat.ts`** — `createHeartbeat({deviceId, tableName, region})` returns a `HealthHeartbeat` with `reportSuccess()` and `reportFailure(reason)`. Both write to `DEVICE_HEALTH#<deviceId>` / `STATE` using `UpdateItemCommand`. Errors are caught and logged but never thrown — the heartbeat path must never break the frame path.
+2. **Wired into `relay.ts`** — the existing `await sendFrameToPixoo(...)` call is now wrapped in try/catch; on success we call `heartbeat.reportSuccess()`, on failure we extract the inner undici/fetch error code (`UND_ERR_CONNECT_TIMEOUT` etc.) and call `heartbeat.reportFailure(code)`. The original error continues to propagate so existing logging is unchanged.
+3. **Configured via `cli.ts`** — three env vars (`PIXOO_DEVICE_ID`, `GLUCAGENT_RECORDS_TABLE`, `GLUCAGENT_REGION`) plus the standard AWS credential chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`). If any of the three are unset, heartbeats are disabled (noop) so local-dev runs don't need creds.
+4. **Updated `deploy/lightsail/setup.sh`** so fresh installs get a commented template of the new env vars; existing `/etc/signage-relay.env` files on running Lightsail boxes need manual edits + a `systemctl restart signage-relay.service`.
+
+## Cross-repo wiring
+
+The IAM user (`signage-relay-heartbeat`) and policy are provisioned in `jwulff/glucagent#131` — a least-privilege policy scoped to `dynamodb:UpdateItem` on the Records table, constrained to `DEVICE_HEALTH#*` leading keys. Access key ID + secret are emitted as SST outputs on first apply; copy them into `/etc/signage-relay.env` on the Lightsail box.
+
+## Test Plan
+
+- [x] `heartbeat.test.ts` — 6 tests (success path command shape, failure path command shape, empty reason → "unknown", DDB rejection on both paths)
+- [x] `relay.test.ts` — 3 new tests (heartbeat.reportSuccess called on frame send, reportFailure called with the cause code on failure, default noop heartbeat works)
+- [x] Full repo suite green: 547 tests across all packages (core 7, diabetes 34, web 45, relay 37, functions 424)
+- [x] Lint clean (0 errors)
+- [ ] After deploy: confirm `[heartbeat] enabled` log line on relay startup
+- [ ] After deploy + glucagent#131 deploy: confirm a `DEVICE_HEALTH#pixoo-home` row appears in the glucagent Records table and gets updated every ~60s
+
+## Deploy Steps
+
+1. Wait for `jwulff/glucagent#131` to merge and GH-Actions-deploy (creates IAM user + access key, sets up monitor cron).
+2. Retrieve the relay's AWS access key from the glucagent SST outputs.
+3. SSH to `ubuntu@signage-relay`, edit `/etc/signage-relay.env` to add the four new lines (device id, table name, region, AWS creds).
+4. `sudo systemctl restart signage-relay`.
+5. Confirm `[heartbeat] enabled` appears in `sudo journalctl -u signage-relay -f`.
+
+## What's Next
+
+- End-to-end verification: unplug the Pixoo for ≥5 min, confirm alert email arrives, plug it back in, confirm recovery email arrives.

--- a/deploy/lightsail/setup.sh
+++ b/deploy/lightsail/setup.sh
@@ -105,6 +105,17 @@ PIXOO_IP=192.168.1.XXX
 
 # Your WebSocket API URL (from SST deployment output)
 WEBSOCKET_URL=wss://ws.your-domain.com
+
+# --- Optional: glucagent Pixoo-health heartbeat (jwulff/glucagent#130) ---
+# Set all three to enable per-frame heartbeats into the glucagent Records
+# table; leave commented out to keep heartbeats disabled (relay still
+# functions normally).
+#
+# PIXOO_DEVICE_ID=pixoo-home
+# GLUCAGENT_RECORDS_TABLE=glucagent-production-RecordsTable-XXXXXXXX
+# GLUCAGENT_REGION=us-east-1
+# AWS_ACCESS_KEY_ID=AKIA...
+# AWS_SECRET_ACCESS_KEY=...
 EOF
     warn "Edit /etc/signage-relay.env with your settings"
 else

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -14,12 +14,14 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.700.0",
     "@signage/core": "workspace:*",
     "commander": "^12.1.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/ws": "^8.5.13",
+    "aws-sdk-client-mock": "^4.1.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^2.1.0"

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -107,19 +107,20 @@ async function getPixooIp(providedIp?: string): Promise<string | null> {
   return selectedIp;
 }
 
-// Build the health heartbeat sink from env vars. All three must be present;
-// otherwise heartbeats are disabled (noop). This keeps local/dev runs from
-// needing AWS credentials.
+// Build the health heartbeat sink from env vars. The table and region are
+// required; deviceId defaults to "pixoo-home" for the single-device
+// deployment. If either required var is unset, heartbeats are disabled
+// (noop), which keeps local/dev runs from needing AWS credentials.
 function buildHeartbeat(): HealthHeartbeat {
-  const deviceId = process.env.PIXOO_DEVICE_ID;
   const tableName = process.env.GLUCAGENT_RECORDS_TABLE;
   const region = process.env.GLUCAGENT_REGION;
-  if (!deviceId || !tableName || !region) {
+  if (!tableName || !region) {
     console.log(
-      "[heartbeat] disabled (set PIXOO_DEVICE_ID, GLUCAGENT_RECORDS_TABLE, GLUCAGENT_REGION to enable)",
+      "[heartbeat] disabled (set GLUCAGENT_RECORDS_TABLE and GLUCAGENT_REGION to enable)",
     );
     return noopHeartbeat;
   }
+  const deviceId = process.env.PIXOO_DEVICE_ID || "pixoo-home";
   console.log(`[heartbeat] enabled — device=${deviceId} region=${region}`);
   return createHeartbeat({ deviceId, tableName, region });
 }

--- a/packages/relay/src/cli.ts
+++ b/packages/relay/src/cli.ts
@@ -7,6 +7,7 @@ import { program } from "commander";
 import { createInterface } from "readline";
 import { startRelay } from "./relay.js";
 import { scanForDevices, getSavedPixooIp, savePixooIp } from "./discovery.js";
+import { createHeartbeat, noopHeartbeat, type HealthHeartbeat } from "./heartbeat.js";
 
 /**
  * Prompt user for yes/no
@@ -106,6 +107,23 @@ async function getPixooIp(providedIp?: string): Promise<string | null> {
   return selectedIp;
 }
 
+// Build the health heartbeat sink from env vars. All three must be present;
+// otherwise heartbeats are disabled (noop). This keeps local/dev runs from
+// needing AWS credentials.
+function buildHeartbeat(): HealthHeartbeat {
+  const deviceId = process.env.PIXOO_DEVICE_ID;
+  const tableName = process.env.GLUCAGENT_RECORDS_TABLE;
+  const region = process.env.GLUCAGENT_REGION;
+  if (!deviceId || !tableName || !region) {
+    console.log(
+      "[heartbeat] disabled (set PIXOO_DEVICE_ID, GLUCAGENT_RECORDS_TABLE, GLUCAGENT_REGION to enable)",
+    );
+    return noopHeartbeat;
+  }
+  console.log(`[heartbeat] enabled — device=${deviceId} region=${region}`);
+  return createHeartbeat({ deviceId, tableName, region });
+}
+
 program
   .name("signage-relay")
   .description("Relay frames from AWS to local Pixoo device")
@@ -133,6 +151,7 @@ program
         pixooIp,
         wsUrl: options.ws,
         terminalId: options.terminal,
+        heartbeat: buildHeartbeat(),
       });
     } catch (error) {
       console.error("Relay error:", error);

--- a/packages/relay/src/heartbeat.test.ts
+++ b/packages/relay/src/heartbeat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mockClient } from "aws-sdk-client-mock";
 import {
   DynamoDBClient,
@@ -12,6 +12,10 @@ beforeEach(() => {
   ddbMock.reset();
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-05-13T07:20:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("noopHeartbeat", () => {

--- a/packages/relay/src/heartbeat.test.ts
+++ b/packages/relay/src/heartbeat.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  DynamoDBClient,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import { createHeartbeat, noopHeartbeat } from "./heartbeat.js";
+
+const ddbMock = mockClient(DynamoDBClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-13T07:20:00.000Z"));
+});
+
+describe("noopHeartbeat", () => {
+  it("does nothing on success and failure (no throw)", async () => {
+    await expect(noopHeartbeat.reportSuccess()).resolves.toBeUndefined();
+    await expect(noopHeartbeat.reportFailure("err")).resolves.toBeUndefined();
+  });
+});
+
+describe("createHeartbeat — reportSuccess", () => {
+  it("updates the device record with lastSuccessAt and resets the failure counter", async () => {
+    ddbMock.on(UpdateItemCommand).resolves({});
+    const hb = createHeartbeat({
+      deviceId: "pixoo-home",
+      tableName: "glucagent-production-RecordsTable-smvstaex",
+      region: "us-east-1",
+    });
+
+    await hb.reportSuccess();
+
+    const calls = ddbMock.commandCalls(UpdateItemCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+    expect(input.TableName).toBe("glucagent-production-RecordsTable-smvstaex");
+    expect(input.Key).toEqual({
+      pk: { S: "DEVICE_HEALTH#pixoo-home" },
+      sk: { S: "STATE" },
+    });
+    expect(input.UpdateExpression).toContain("lastSuccessAt");
+    expect(input.UpdateExpression).toContain("consecutiveFailures");
+    expect(input.UpdateExpression).toContain("deviceId");
+    expect(input.ExpressionAttributeValues?.[":now"]?.S).toBe("2026-05-13T07:20:00.000Z");
+    expect(input.ExpressionAttributeValues?.[":zero"]?.N).toBe("0");
+    expect(input.ExpressionAttributeValues?.[":deviceId"]?.S).toBe("pixoo-home");
+  });
+});
+
+describe("createHeartbeat — reportFailure", () => {
+  it("updates lastFailureAt, increments consecutiveFailures, records reason", async () => {
+    ddbMock.on(UpdateItemCommand).resolves({});
+    const hb = createHeartbeat({
+      deviceId: "pixoo-home",
+      tableName: "test-table",
+      region: "us-east-1",
+    });
+
+    await hb.reportFailure("UND_ERR_CONNECT_TIMEOUT");
+
+    const calls = ddbMock.commandCalls(UpdateItemCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+    expect(input.UpdateExpression).toContain("lastFailureAt");
+    expect(input.UpdateExpression).toContain("consecutiveFailures");
+    expect(input.UpdateExpression).toContain("lastFailureReason");
+    expect(input.ExpressionAttributeValues?.[":reason"]?.S).toBe("UND_ERR_CONNECT_TIMEOUT");
+    expect(input.ExpressionAttributeValues?.[":one"]?.N).toBe("1");
+  });
+
+  it("uses 'unknown' when reason is empty", async () => {
+    ddbMock.on(UpdateItemCommand).resolves({});
+    const hb = createHeartbeat({
+      deviceId: "pixoo-home",
+      tableName: "test-table",
+      region: "us-east-1",
+    });
+
+    await hb.reportFailure("");
+
+    const input = ddbMock.commandCalls(UpdateItemCommand)[0].args[0].input;
+    expect(input.ExpressionAttributeValues?.[":reason"]?.S).toBe("unknown");
+  });
+});
+
+describe("createHeartbeat — best-effort error handling", () => {
+  it("does not throw when DynamoDB rejects on success path", async () => {
+    ddbMock.on(UpdateItemCommand).rejects(new Error("AccessDenied"));
+    const hb = createHeartbeat({
+      deviceId: "pixoo-home",
+      tableName: "test-table",
+      region: "us-east-1",
+    });
+    await expect(hb.reportSuccess()).resolves.toBeUndefined();
+  });
+
+  it("does not throw when DynamoDB rejects on failure path", async () => {
+    ddbMock.on(UpdateItemCommand).rejects(new Error("ResourceNotFound"));
+    const hb = createHeartbeat({
+      deviceId: "pixoo-home",
+      tableName: "test-table",
+      region: "us-east-1",
+    });
+    await expect(hb.reportFailure("X")).resolves.toBeUndefined();
+  });
+});

--- a/packages/relay/src/heartbeat.ts
+++ b/packages/relay/src/heartbeat.ts
@@ -1,0 +1,91 @@
+/**
+ * Pixoo health heartbeat — reports per-frame success/failure to glucagent's
+ * DynamoDB so glucagent's monitor Lambda can decide whether to email the
+ * owner. See jwulff/glucagent#130 for the schema and decision logic.
+ *
+ * Writes are best-effort: any error is logged but never thrown, so the relay
+ * keeps trying to push frames even when the heartbeat path is broken
+ * (credentials missing, table renamed, transient DDB outage).
+ */
+
+import {
+  DynamoDBClient,
+  UpdateItemCommand,
+} from "@aws-sdk/client-dynamodb";
+
+export interface HealthHeartbeat {
+  reportSuccess(): Promise<void>;
+  reportFailure(reason: string): Promise<void>;
+}
+
+export interface HeartbeatOptions {
+  deviceId: string;
+  tableName: string;
+  region: string;
+}
+
+export const noopHeartbeat: HealthHeartbeat = {
+  async reportSuccess() {},
+  async reportFailure() {},
+};
+
+export function createHeartbeat(opts: HeartbeatOptions): HealthHeartbeat {
+  const client = new DynamoDBClient({ region: opts.region });
+  const key = {
+    pk: { S: `DEVICE_HEALTH#${opts.deviceId}` },
+    sk: { S: "STATE" },
+  };
+
+  return {
+    async reportSuccess() {
+      const now = new Date().toISOString();
+      try {
+        await client.send(
+          new UpdateItemCommand({
+            TableName: opts.tableName,
+            Key: key,
+            UpdateExpression:
+              "SET deviceId = :deviceId, lastSuccessAt = :now, consecutiveFailures = :zero",
+            ExpressionAttributeValues: {
+              ":deviceId": { S: opts.deviceId },
+              ":now": { S: now },
+              ":zero": { N: "0" },
+            },
+          }),
+        );
+      } catch (err) {
+        console.error(
+          "[heartbeat] reportSuccess failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    },
+
+    async reportFailure(reason: string) {
+      const now = new Date().toISOString();
+      const safeReason = reason && reason.length > 0 ? reason : "unknown";
+      try {
+        await client.send(
+          new UpdateItemCommand({
+            TableName: opts.tableName,
+            Key: key,
+            UpdateExpression:
+              "SET deviceId = :deviceId, lastFailureAt = :now, lastFailureReason = :reason " +
+              "ADD consecutiveFailures :one",
+            ExpressionAttributeValues: {
+              ":deviceId": { S: opts.deviceId },
+              ":now": { S: now },
+              ":reason": { S: safeReason },
+              ":one": { N: "1" },
+            },
+          }),
+        );
+      } catch (err) {
+        console.error(
+          "[heartbeat] reportFailure failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    },
+  };
+}

--- a/packages/relay/src/relay.test.ts
+++ b/packages/relay/src/relay.test.ts
@@ -61,6 +61,10 @@ describe("relay", () => {
   });
 
   afterEach(() => {
+    // startRelay creates a long-lived setInterval keepalive that the tests
+    // never tear down; clear it so vitest can exit cleanly.
+    vi.clearAllTimers();
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 

--- a/packages/relay/src/relay.test.ts
+++ b/packages/relay/src/relay.test.ts
@@ -10,14 +10,18 @@ class MockWebSocket extends EventEmitter {
   close = vi.fn();
 }
 
-const { mockInitializePixoo, mockSendFrameToPixoo } = vi.hoisted(() => ({
-  mockInitializePixoo: vi.fn(),
-  mockSendFrameToPixoo: vi.fn(),
-}));
+const { mockInitializePixoo, mockSendFrameToPixoo, capturedWs } = vi.hoisted(() => {
+  return {
+    mockInitializePixoo: vi.fn(),
+    mockSendFrameToPixoo: vi.fn(),
+    capturedWs: { instance: null as MockWebSocket | null },
+  };
+});
 
 vi.mock("ws", () => ({
   default: vi.fn(() => {
     const ws = new MockWebSocket();
+    capturedWs.instance = ws;
     // Emit open event on next tick to simulate async connection
     setTimeout(() => ws.emit("open"), 0);
     return ws;
@@ -29,14 +33,31 @@ vi.mock("./pixoo-client.js", () => ({
   sendFrameToPixoo: mockSendFrameToPixoo,
 }));
 
-// Note: We can't easily test startRelay because it runs forever (await new Promise(() => {}))
-// Instead, we test the WebSocket event handlers by mocking the module internals
+import { startRelay } from "./relay.js";
+import type { HealthHeartbeat } from "./heartbeat.js";
+
+function makeFrameMessage() {
+  // 1x1 RGB frame, base64-encoded
+  const data = Buffer.from([0, 0, 0]).toString("base64");
+  return {
+    type: "frame",
+    payload: { frame: { width: 1, height: 1, data } },
+    timestamp: Date.now(),
+  };
+}
+
+async function flushMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
 
 describe("relay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitializePixoo.mockResolvedValue(undefined);
     mockSendFrameToPixoo.mockResolvedValue(undefined);
+    capturedWs.instance = null;
   });
 
   afterEach(() => {
@@ -45,7 +66,6 @@ describe("relay", () => {
 
   describe("initializePixoo integration", () => {
     it("initializePixoo is called with correct IP", async () => {
-      // We can test the pixoo-client mocks are correctly set up
       await mockInitializePixoo("192.168.1.100");
       expect(mockInitializePixoo).toHaveBeenCalledWith("192.168.1.100");
     });
@@ -57,8 +77,56 @@ describe("relay", () => {
     });
   });
 
-  // Note: Full integration testing of startRelay would require:
-  // 1. A way to stop the relay (not implemented - runs forever)
-  // 2. Complex async coordination of WebSocket events
-  // For now, the pixoo-client tests cover the critical paths
+  describe("heartbeat wiring", () => {
+    it("calls heartbeat.reportSuccess after a successful frame send", async () => {
+      const hb: HealthHeartbeat = {
+        reportSuccess: vi.fn().mockResolvedValue(undefined),
+        reportFailure: vi.fn().mockResolvedValue(undefined),
+      };
+
+      // Fire-and-forget — startRelay never resolves on purpose
+      void startRelay({ pixooIp: "192.168.1.50", wsUrl: "wss://x", heartbeat: hb });
+      await new Promise((r) => setTimeout(r, 5)); // let "open" fire
+      expect(capturedWs.instance).not.toBeNull();
+
+      capturedWs.instance!.emit("message", JSON.stringify(makeFrameMessage()));
+      await flushMicrotasks(20);
+
+      expect(mockSendFrameToPixoo).toHaveBeenCalled();
+      expect(hb.reportSuccess).toHaveBeenCalledTimes(1);
+      expect(hb.reportFailure).not.toHaveBeenCalled();
+    });
+
+    it("calls heartbeat.reportFailure with the error code when frame send fails", async () => {
+      const hb: HealthHeartbeat = {
+        reportSuccess: vi.fn().mockResolvedValue(undefined),
+        reportFailure: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const fetchErr = new Error("fetch failed") as Error & { cause?: { code?: string } };
+      fetchErr.cause = { code: "UND_ERR_CONNECT_TIMEOUT" };
+      mockSendFrameToPixoo.mockRejectedValueOnce(fetchErr);
+
+      void startRelay({ pixooIp: "192.168.1.50", wsUrl: "wss://x", heartbeat: hb });
+      await new Promise((r) => setTimeout(r, 5));
+
+      capturedWs.instance!.emit("message", JSON.stringify(makeFrameMessage()));
+      await flushMicrotasks(20);
+
+      expect(hb.reportFailure).toHaveBeenCalledTimes(1);
+      expect(hb.reportFailure).toHaveBeenCalledWith("UND_ERR_CONNECT_TIMEOUT");
+      expect(hb.reportSuccess).not.toHaveBeenCalled();
+    });
+
+    it("uses the noop heartbeat by default when none is provided", async () => {
+      // No heartbeat option — should still work without error
+      void startRelay({ pixooIp: "192.168.1.50", wsUrl: "wss://x" });
+      await new Promise((r) => setTimeout(r, 5));
+
+      capturedWs.instance!.emit("message", JSON.stringify(makeFrameMessage()));
+      await flushMicrotasks(20);
+
+      expect(mockSendFrameToPixoo).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/relay/src/relay.ts
+++ b/packages/relay/src/relay.ts
@@ -93,9 +93,15 @@ export async function startRelay(options: RelayOptions): Promise<void> {
           try {
             await sendFrameToPixoo(pixooIp, frame);
             console.log("Frame sent to Pixoo");
-            void heartbeat.reportSuccess();
+            // Fire-and-forget. The HealthHeartbeat contract is never-throws,
+            // but defend against alternate implementations rejecting.
+            heartbeat
+              .reportSuccess()
+              .catch((e) => console.error("[heartbeat] unexpected reject:", e));
           } catch (frameErr) {
-            void heartbeat.reportFailure(extractFailureReason(frameErr));
+            heartbeat
+              .reportFailure(extractFailureReason(frameErr))
+              .catch((e) => console.error("[heartbeat] unexpected reject:", e));
             throw frameErr;
           }
         } else if (message.type === "ping") {

--- a/packages/relay/src/relay.ts
+++ b/packages/relay/src/relay.ts
@@ -9,6 +9,7 @@ import { sendFrameToPixoo, initializePixoo } from "./pixoo-client.js";
 import type { WsMessage, FramePayload } from "@signage/core";
 import { decodeBase64ToPixels } from "@signage/core";
 import { createBackoffController } from "./backoff.js";
+import { noopHeartbeat, type HealthHeartbeat } from "./heartbeat.js";
 
 // Force HTTP/1.1 to prevent ALPN from negotiating HTTP/2 (which doesn't support WebSocket)
 const agent = new https.Agent({
@@ -19,10 +20,12 @@ export interface RelayOptions {
   pixooIp: string;
   wsUrl: string;
   terminalId?: string;
+  heartbeat?: HealthHeartbeat;
 }
 
 export async function startRelay(options: RelayOptions): Promise<void> {
   const { pixooIp, wsUrl, terminalId } = options;
+  const heartbeat = options.heartbeat ?? noopHeartbeat;
 
   // Initialize Pixoo to custom channel mode
   try {
@@ -87,8 +90,14 @@ export async function startRelay(options: RelayOptions): Promise<void> {
             payload.frame.width,
             payload.frame.height
           );
-          await sendFrameToPixoo(pixooIp, frame);
-          console.log("Frame sent to Pixoo");
+          try {
+            await sendFrameToPixoo(pixooIp, frame);
+            console.log("Frame sent to Pixoo");
+            void heartbeat.reportSuccess();
+          } catch (frameErr) {
+            void heartbeat.reportFailure(extractFailureReason(frameErr));
+            throw frameErr;
+          }
         } else if (message.type === "ping") {
           const pong: WsMessage = {
             type: "pong",
@@ -130,4 +139,15 @@ export async function startRelay(options: RelayOptions): Promise<void> {
 
   // Keep process alive
   await new Promise(() => {});
+}
+
+// Extract a stable short code from undici/fetch errors. Falls back to the
+// error message and ultimately "unknown" so heartbeat writes always succeed.
+function extractFailureReason(err: unknown): string {
+  if (err instanceof Error) {
+    const cause = (err as Error & { cause?: { code?: string } }).cause;
+    if (cause && typeof cause.code === "string") return cause.code;
+    if (err.message) return err.message;
+  }
+  return "unknown";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
 
   packages/relay:
     dependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.700.0
+        version: 3.969.0
       '@signage/core':
         specifier: workspace:*
         version: link:../core
@@ -153,6 +156,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -399,6 +405,7 @@ packages:
   '@aws-sdk/middleware-websocket@3.969.0':
     resolution: {integrity: sha512-Zdd9sGDkZgOMpySpkJuJT1bi3D5Zj0eTvVLJxob1nnj5usXenL58B/3MRPKe7yWJheHxLr67mR/s9vLnGcIsRQ==}
     engines: {node: '>= 14.0.0'}
+    deprecated: Please update your @aws-sdk client to a more recent version, such as https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.982.0, if using browser-based WebSocket bidirectional streaming.
 
   '@aws-sdk/nested-clients@3.969.0':
     resolution: {integrity: sha512-MJrejgODxVYZjQjSpPLJkVuxnbrue1x1R8+as3anT5V/wk9Qc/Pf5B1IFjM3Ak6uOtzuRYNY4auOvcg4U8twDA==}
@@ -1297,6 +1304,18 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@11.2.2':
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@sinonjs/samsam@8.0.3':
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+
   '@smithy/abort-controller@4.2.10':
     resolution: {integrity: sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==}
     engines: {node: '>=18.0.0'}
@@ -1724,6 +1743,12 @@ packages:
   '@types/react@19.2.8':
     resolution: {integrity: sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==}
 
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1914,6 +1939,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
+
   aws-sdk@2.1692.0:
     resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
     engines: {node: '>= 10.0.0'}
@@ -1980,6 +2008,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -2177,6 +2206,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -2705,6 +2738,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2833,6 +2869,9 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  nise@6.1.5:
+    resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -3155,6 +3194,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -3355,6 +3397,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
 
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
@@ -5096,6 +5142,23 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@11.2.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.3':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
   '@smithy/abort-controller@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -5755,6 +5818,12 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.6
@@ -6007,6 +6076,12 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws-sdk-client-mock@4.1.0:
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
 
   aws-sdk@2.1692.0:
     dependencies:
@@ -6275,6 +6350,8 @@ snapshots:
   devtools-protocol@0.0.1367902: {}
 
   diff-sequences@29.6.3: {}
+
+  diff@5.2.2: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -6902,6 +6979,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  just-extend@6.2.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7010,6 +7089,13 @@ snapshots:
   negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
+
+  nise@6.1.5:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.4.0
+      just-extend: 6.2.0
+      path-to-regexp: 8.3.0
 
   node-releases@2.0.27: {}
 
@@ -7389,6 +7475,15 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sinon@18.0.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.2
+      nise: 6.1.5
+      supports-color: 7.2.0
+
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@8.0.5:
@@ -7593,6 +7688,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.0.8: {}
 
   type-detect@4.1.0: {}
 


### PR DESCRIPTION
## Summary
- Per-frame health heartbeats from the relay to glucagent's `Records` table (`DEVICE_HEALTH#<deviceId>` / `STATE`).
- `reportSuccess()` clears the failure counter; `reportFailure(reason)` increments it and records the inner undici error code (e.g. `UND_ERR_CONNECT_TIMEOUT`) so the alert email can quote the exact cause.
- All DynamoDB writes are best-effort — errors are caught and logged but never thrown. Heartbeat path can fail without affecting frame delivery.
- Heartbeats are **disabled** unless all three env vars are set (`PIXOO_DEVICE_ID`, `GLUCAGENT_RECORDS_TABLE`, `GLUCAGENT_REGION`), so local-dev runs need no AWS credentials.

## Why
When the Pixoo's HTTP daemon hangs (a known Divoom firmware quirk — device pings but port 80 dies), the display goes dark and the only signal is `journalctl` on the Lightsail relay. The cloud half of this lives in `jwulff/glucagent#131` (monitor Lambda + email). This PR is the relay-side that produces the heartbeats the monitor reads.

Diagnosed manually on 2026-05-13 when the Pixoo hung at 00:14 PT.

## Test Plan
- [x] `heartbeat.test.ts` — 6 unit tests (command shape on success, command shape on failure, empty-reason fallback, DDB rejection on both paths)
- [x] `relay.test.ts` — 3 new wiring tests (heartbeat.reportSuccess invoked on frame send, reportFailure invoked with `cause.code` on failure, default noop heartbeat works)
- [x] Full repo suite green: 547 tests (core 7 / diabetes 34 / web 45 / relay 37 / functions 424)
- [x] Lint clean (0 errors)
- [ ] After both PRs deploy: edit `/etc/signage-relay.env` on Lightsail with the new env vars + AWS access keys (from glucagent SST outputs), `systemctl restart signage-relay`, confirm `[heartbeat] enabled` log line
- [ ] Induce a Pixoo outage (unplug ≥5 min) and verify the alert email arrives

## Deployment

This PR's code is safe to merge before glucagent#131 deploys — the relay continues to function exactly as today when the new env vars are unset. Production heartbeats only start once the env file on Lightsail is updated.

See `changes/2026-05-14-0507-relay-pixoo-health-heartbeat.md` for the full why/how and deploy steps.

Companion PR: `jwulff/glucagent#131`.

Closes #254